### PR TITLE
Fix created flag in write_file

### DIFF
--- a/src/tools/file_tools.py
+++ b/src/tools/file_tools.py
@@ -154,7 +154,7 @@ class FileTools:
                 'success': True,
                 'file_path': file_path,
                 'size_bytes': len(content.encode(encoding)),
-                'created': (not os.path.exists(file_path)) if not overwrite else (not file_existed)
+                'created': not file_existed
             }
             
         except PermissionError:

--- a/src/tools/file_tools.py
+++ b/src/tools/file_tools.py
@@ -132,8 +132,10 @@ class FileTools:
                     'error': f"Access to path '{file_path}' is restricted"
                 }
             
+            file_existed = os.path.exists(file_path)
+
             # Check if file exists and overwrite is False
-            if os.path.exists(file_path) and not overwrite:
+            if file_existed and not overwrite:
                 return {
                     'success': False,
                     'error': f"File '{file_path}' already exists and overwrite is disabled"
@@ -152,7 +154,7 @@ class FileTools:
                 'success': True,
                 'file_path': file_path,
                 'size_bytes': len(content.encode(encoding)),
-                'created': not os.path.exists(file_path) if not overwrite else None
+                'created': (not os.path.exists(file_path)) if not overwrite else (not file_existed)
             }
             
         except PermissionError:

--- a/tests/test_file_tools.py
+++ b/tests/test_file_tools.py
@@ -1,0 +1,19 @@
+import os
+from src.tools.file_tools import FileTools
+
+
+def test_write_file_created_flag_new(tmp_path):
+    tools = FileTools()
+    file_path = tmp_path / "test.txt"
+    result = tools.write_file(str(file_path), "content", overwrite=True)
+    assert result["created"] is True
+    assert file_path.exists()
+
+
+def test_write_file_created_flag_overwrite(tmp_path):
+    tools = FileTools()
+    file_path = tmp_path / "test.txt"
+    file_path.write_text("old")
+    result = tools.write_file(str(file_path), "new", overwrite=True)
+    assert result["created"] is False
+    assert file_path.read_text() == "new"


### PR DESCRIPTION
## Summary
- track file existence before writing
- use tracked flag when overwriting
- add tests for new file and overwrite cases

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68557d5269808328a68380beca9e71a8