### PR TITLE
Fix duplicate user message in GUI history

### DIFF
--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -310,10 +310,9 @@ SYSTEM OPERATIONS:
 After using a tool, I'll give you the result and you can respond normally to the user."""
         
         messages = [
-            {"role": "system", "content": system_message},
-            {"role": "user", "content": message}
+            {"role": "system", "content": system_message}
         ]
-        
+
         # Add recent conversation history
         messages.extend(self.conversation_history[-6:])
         messages.append({"role": "user", "content": message})


### PR DESCRIPTION
## Summary
- construct the message list correctly in `chat_with_tools`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685585ae9eec8328aebb55435de10fd1