### PR TITLE
Update README psutil dependency note

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ A powerful, local-first AI assistant with tools that works with [Jan.ai](https:/
 ### Dependencies
 - `requests` - HTTP client for API communication
 - `tkinter` - GUI framework (usually included with Python)
-- `psutil` - System monitoring (optional but recommended)
+- `psutil` - System monitoring (installed by default via `requirements.txt`)
 
 ## 🛠️ Installation
 


### PR DESCRIPTION
## Summary
- update dependency section to note psutil installs by default

## Testing
- `python -m pytest tests/`

------
https://chatgpt.com/codex/tasks/task_e_685587a149348328801b38e69af6e0da