### PR TITLE
Add API client unit tests

### DIFF
--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -22,6 +22,7 @@ def test_chat_completion_success():
     with patch.object(client.session, "post", return_value=mock_response) as post:
         response = client.chat_completion(messages)
         post.assert_called_once()
+        mock_response.raise_for_status.assert_called_once()
     assert response["choices"][0]["message"]["content"] == "hello"
     assert client.extract_content(response) == "hello"
 


### PR DESCRIPTION
## Summary
- test APIClient chat completion success and extract content
- test HTTP 400 error handling when model isn't loaded
- test connection error handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685589bd99a483288aa1568e96cc9f6e