### PR TITLE
Fix network connectivity success flag

### DIFF
--- a/src/tools/system_tools.py
+++ b/src/tools/system_tools.py
@@ -296,7 +296,7 @@ class SystemTools:
             
             result = self.run_command(ping_cmd)
 
-            if result.get('success') and result.get('return_code') == 0:
+            if result.get('success', False) and result.get('return_code', -1) == 0:
                 return {
                     'success': True,
                     'connected': True,

--- a/src/tools/system_tools.py
+++ b/src/tools/system_tools.py
@@ -295,8 +295,8 @@ class SystemTools:
                 ping_cmd = f"ping -c 1 -W {timeout} {host}"
             
             result = self.run_command(ping_cmd)
-            
-            if result['success'] and result['return_code'] == 0:
+
+            if result.get('success') and result.get('return_code') == 0:
                 return {
                     'success': True,
                     'connected': True,
@@ -305,7 +305,7 @@ class SystemTools:
                 }
             else:
                 return {
-                    'success': True,
+                    'success': False,
                     'connected': False,
                     'host': host,
                     'message': f"Could not connect to {host}",

--- a/tests/test_system_tools.py
+++ b/tests/test_system_tools.py
@@ -1,0 +1,33 @@
+from unittest.mock import patch
+from src.tools.system_tools import SystemTools
+
+
+def test_check_network_connectivity_success():
+    tools = SystemTools()
+    mock_result = {'success': True, 'return_code': 0, 'stdout': 'ok', 'stderr': ''}
+    with patch.object(tools, "run_command", return_value=mock_result) as run_cmd:
+        result = tools.check_network_connectivity("example.com")
+        run_cmd.assert_called_once()
+    assert result["success"] is True
+    assert result["connected"] is True
+    assert result["host"] == "example.com"
+
+
+def test_check_network_connectivity_failure_nonzero():
+    tools = SystemTools()
+    mock_result = {'success': True, 'return_code': 1, 'stderr': 'unreachable'}
+    with patch.object(tools, "run_command", return_value=mock_result):
+        result = tools.check_network_connectivity("example.com")
+    assert result["success"] is False
+    assert result["connected"] is False
+    assert "unreachable" in result["error"]
+
+
+def test_check_network_connectivity_failure_error():
+    tools = SystemTools()
+    mock_result = {'success': False, 'return_code': 1, 'stderr': 'timeout'}
+    with patch.object(tools, "run_command", return_value=mock_result):
+        result = tools.check_network_connectivity("example.com")
+    assert result["success"] is False
+    assert result["connected"] is False
+    assert "timeout" in result["error"]


### PR DESCRIPTION
## Summary
- mark ping success False when command fails
- add tests for ping success and failure cases

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68558be90f1c83288b66e793188eb279