### PR TITLE
Enable ping command and add connectivity tests

### DIFF
--- a/config/config.example.json
+++ b/config/config.example.json
@@ -23,7 +23,7 @@
     "web_search": false
   },
   "security": {
-    "allowed_commands": ["ls", "pwd", "cat", "echo"],
+    "allowed_commands": ["ls", "pwd", "cat", "echo", "ping"],
     "restricted_paths": ["/etc", "/sys", "/proc"],
     "max_file_size": "10MB"
   }

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -73,7 +73,7 @@ class Config:
                 "web_search": False
             },
             "security": {
-                "allowed_commands": ["ls", "pwd", "cat", "echo", "python3", "python"],
+                "allowed_commands": ["ls", "pwd", "cat", "echo", "python3", "python", "ping"],
                 "restricted_paths": ["/etc", "/sys", "/proc"],
                 "max_file_size": "10MB"
             }

--- a/src/tools/system_tools.py
+++ b/src/tools/system_tools.py
@@ -16,7 +16,7 @@ class SystemTools:
         self.allowed_commands = allowed_commands or [
             "ls", "pwd", "cat", "echo", "python3", "python", "pip", "pip3",
             "git", "curl", "wget", "grep", "find", "wc", "head", "tail",
-            "sort", "uniq", "date", "whoami", "which", "type"
+            "sort", "uniq", "date", "whoami", "which", "type", "ping"
         ]
         self.timeout = timeout
         self.system = platform.system().lower()
@@ -304,12 +304,13 @@ class SystemTools:
                     'message': f"Successfully connected to {host}"
                 }
             else:
+                error_msg = result.get('stderr') or result.get('error', 'Unknown error')
                 return {
                     'success': False,
                     'connected': False,
                     'host': host,
                     'message': f"Could not connect to {host}",
-                    'error': result.get('stderr', 'Unknown error')
+                    'error': error_msg
                 }
                 
         except Exception as e:

--- a/tests/test_system_tools.py
+++ b/tests/test_system_tools.py
@@ -1,5 +1,6 @@
 from unittest.mock import patch
 from src.tools.system_tools import SystemTools
+from src.core.config import Config
 
 
 def test_check_network_connectivity_success():
@@ -31,3 +32,25 @@ def test_check_network_connectivity_failure_error():
     assert result["success"] is False
     assert result["connected"] is False
     assert "timeout" in result["error"]
+
+
+def test_check_network_connectivity_failure_result_error():
+    tools = SystemTools()
+    mock_result = {'success': False, 'error': 'not allowed'}
+    with patch.object(tools, "run_command", return_value=mock_result):
+        result = tools.check_network_connectivity("example.com")
+    assert result["success"] is False
+    assert result["connected"] is False
+    assert "not allowed" in result["error"]
+
+
+def test_check_network_connectivity_with_default_config(tmp_path):
+    cfg = Config(config_path=str(tmp_path / "config.json"))
+    tools = SystemTools(allowed_commands=cfg.get("security.allowed_commands"))
+    assert "ping" in tools.allowed_commands
+    mock_result = {'success': True, 'return_code': 0, 'stdout': 'ok', 'stderr': ''}
+    with patch.object(tools, "run_command", return_value=mock_result) as run_cmd:
+        result = tools.check_network_connectivity("example.com")
+        run_cmd.assert_called_once()
+    assert result["success"] is True
+    assert result["connected"] is True


### PR DESCRIPTION
## Summary
- support `ping` in SystemTools default allowed commands
- include `ping` in default config allowed commands
- document new default in example config
- expose error message in `check_network_connectivity`
- test connectivity works with default config and result error

## Testing
- `pip install requests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685592f63e688328a8153338d429c906