### PR TITLE
fix: use reentrant lock in MemoryManager

### DIFF
--- a/src/core/memory.py
+++ b/src/core/memory.py
@@ -10,14 +10,18 @@ import threading
 
 
 class MemoryManager:
-    """Manages persistent memory for the assistant"""
+    """Manages persistent memory for the assistant.
+
+    A reentrant lock is used to avoid nested locking issues when methods
+    like ``remember`` or ``recall`` trigger ``save_memory`` internally.
+    """
     
     def __init__(self, memory_file: str, max_entries: int = 1000, auto_save: bool = True):
         self.memory_file = memory_file
         self.max_entries = max_entries
         self.auto_save = auto_save
         self.memory_data = {}
-        self._lock = threading.Lock()
+        self._lock = threading.RLock()
         
         # Ensure directory exists
         self._ensure_memory_dir()

--- a/tests/test_memory_manager.py
+++ b/tests/test_memory_manager.py
@@ -22,3 +22,15 @@ def test_memory_persistence(tmp_path):
     recalled = new_manager.recall("greeting")
     assert recalled is not None
     assert recalled.get("value") == "hello"
+
+
+def test_auto_save_no_deadlock(tmp_path):
+    """Calling remember and recall with auto_save enabled should not deadlock."""
+    temp_path = tmp_path / "memory_test.db"
+    manager = MemoryManager(str(temp_path))
+
+    assert manager.remember("topic", "value") is True
+
+    recalled = manager.recall("topic")
+    assert recalled is not None
+    assert recalled.get("value") == "value"


### PR DESCRIPTION
## Summary
- replace `threading.Lock` with `threading.RLock`
- clarify lock usage in `MemoryManager` docstring
- add regression test to ensure remember/recall don't deadlock

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68559d4b08e88328acbb8103731378cb