### PR TITLE
Fix memory lock comment and tests

### DIFF
--- a/src/core/memory.py
+++ b/src/core/memory.py
@@ -12,8 +12,9 @@ import threading
 class MemoryManager:
     """Manages persistent memory for the assistant.
 
-    A reentrant lock is used to avoid nested locking issues when methods
-    like ``remember`` or ``recall`` trigger ``save_memory`` internally.
+    The class uses :class:`threading.RLock`, a reentrant lock, so that
+    methods such as ``remember`` or ``recall`` can call ``save_memory``
+    while already holding the lock without causing a deadlock.
     """
     
     def __init__(self, memory_file: str, max_entries: int = 1000, auto_save: bool = True):


### PR DESCRIPTION
## Summary
- clarify how `MemoryManager` uses `threading.RLock`
- keep auto-save test together with persistence tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855a1bfcd608328951d8b1516eaa3bb