### PR TITLE
Fix test_api threading and add timestamps to memory stats

### DIFF
--- a/src/core/memory.py
+++ b/src/core/memory.py
@@ -245,22 +245,24 @@ class MemoryManager:
                 return {
                     'total_entries': 0,
                     'categories': [],
+                    'timestamps': {},
                     'oldest_entry': None,
                     'newest_entry': None,
                     'most_accessed': None
                 }
-            
-            timestamps = [m.get('timestamp', '') for m in self.memory_data.values()]
-            access_counts = [(k, m.get('access_count', 0)) for k, m in self.memory_data.items()]
-            
-            most_accessed = max(access_counts, key=lambda x: x[1]) if access_counts else None
-            
+
+            timestamps = {k: m.get('timestamp', '') for k, m in self.memory_data.items()}
+            access_counts = {k: m.get('access_count', 0) for k, m in self.memory_data.items()}
+
+            most_accessed_key = max(access_counts, key=access_counts.get) if access_counts else None
+
             return {
                 'total_entries': len(self.memory_data),
                 'categories': self.get_categories(),
-                'oldest_entry': min(timestamps) if timestamps else None,
-                'newest_entry': max(timestamps) if timestamps else None,
-                'most_accessed': most_accessed[0] if most_accessed and most_accessed[1] > 0 else None
+                'timestamps': timestamps,
+                'oldest_entry': min(timestamps.values()) if timestamps else None,
+                'newest_entry': max(timestamps.values()) if timestamps else None,
+                'most_accessed': most_accessed_key if most_accessed_key and access_counts[most_accessed_key] > 0 else None
             }
     
     def clear_all(self) -> bool:

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -557,7 +557,7 @@ After using a tool, I'll give you the result and you can respond normally to the
     def test_api(self):
         """Test API connection"""
         def test():
-            self.update_status("🔄 Testing API...", "#ffff00")
+            self.root.after(0, lambda: self.update_status("🔄 Testing API...", "#ffff00"))
             status = self.api_client.test_connection()
             
             if status['connected']:


### PR DESCRIPTION
## Summary
- wrap all GUI updates in `test_api()` with `root.after`
- expose timestamps in `MemoryManager.get_stats` to satisfy tests

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855a6687a3083289bc0828a205be669