### PR TITLE
Fix memory stats structure

### DIFF
--- a/src/core/memory.py
+++ b/src/core/memory.py
@@ -250,7 +250,7 @@ class MemoryManager:
                     'most_accessed': None
                 }
             
-            timestamps = [m.get('timestamp', '') for m in self.memory_data.values()]
+            timestamps = {k: m.get('timestamp', '') for k, m in self.memory_data.items()}
             access_counts = [(k, m.get('access_count', 0)) for k, m in self.memory_data.items()]
             
             most_accessed = max(access_counts, key=lambda x: x[1]) if access_counts else None
@@ -258,8 +258,9 @@ class MemoryManager:
             return {
                 'total_entries': len(self.memory_data),
                 'categories': self.get_categories(),
-                'oldest_entry': min(timestamps) if timestamps else None,
-                'newest_entry': max(timestamps) if timestamps else None,
+                'timestamps': timestamps,
+                'oldest_entry': min(timestamps.values()) if timestamps else None,
+                'newest_entry': max(timestamps.values()) if timestamps else None,
                 'most_accessed': most_accessed[0] if most_accessed and most_accessed[1] > 0 else None
             }
     

--- a/tests/test_memory_manager.py
+++ b/tests/test_memory_manager.py
@@ -91,4 +91,3 @@ def test_memory_get_stats(tmp_path):
     assert stats["oldest_entry"] == min(stats["timestamps"].values())
     assert stats["newest_entry"] == max(stats["timestamps"].values())
     assert stats["most_accessed"] == "a"
-    assert stats["most_accessed"] == "a"


### PR DESCRIPTION
## Summary
- return a timestamps dictionary in `MemoryManager.get_stats`
- remove duplicated assert from `test_memory_manager`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855a67b70ac8328b1c8f9bcf7e40b58