### PR TITLE
Update README defaults and memory stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,8 @@ python -m pytest tests/
 
 ## ⚙️ Configuration
 
-Edit `config/config.json` to customize settings:
+Edit `config/config.json` to customize settings. The snippet below shows the
+default values from `src/core/config.py`, which you can customize:
 
 ```json
 {
@@ -105,8 +106,8 @@ Edit `config/config.json` to customize settings:
     "window_size": "800x600"
   },
   "security": {
-    "allowed_commands": ["ls", "pwd", "python3", "ping"],
-    "restricted_paths": ["/etc", "/sys"]
+    "allowed_commands": ["ls", "pwd", "cat", "echo", "python3", "python", "ping"],
+    "restricted_paths": ["/etc", "/sys", "/proc"]
   }
 }
 ```

--- a/src/core/memory.py
+++ b/src/core/memory.py
@@ -250,16 +250,17 @@ class MemoryManager:
                     'most_accessed': None
                 }
             
-            timestamps = [m.get('timestamp', '') for m in self.memory_data.values()]
+            timestamps = {k: m.get('timestamp', '') for k, m in self.memory_data.items()}
             access_counts = [(k, m.get('access_count', 0)) for k, m in self.memory_data.items()]
-            
+
             most_accessed = max(access_counts, key=lambda x: x[1]) if access_counts else None
-            
+
             return {
                 'total_entries': len(self.memory_data),
                 'categories': self.get_categories(),
-                'oldest_entry': min(timestamps) if timestamps else None,
-                'newest_entry': max(timestamps) if timestamps else None,
+                'timestamps': timestamps,
+                'oldest_entry': min(timestamps.values()) if timestamps else None,
+                'newest_entry': max(timestamps.values()) if timestamps else None,
                 'most_accessed': most_accessed[0] if most_accessed and most_accessed[1] > 0 else None
             }
     


### PR DESCRIPTION
## Summary
- document the default config values in README
- expose timestamps via `MemoryManager.get_stats`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855a66cc8dc8328bf4a6435d0893648