### PR TITLE
Add EnhancedConfig with dotenv support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,20 @@
+# Jan Assistant Pro Environment Configuration
+# Copy this file to .env and customize your values
+
+# API Configuration
+JAN_ASSISTANT_API_BASE_URL=http://127.0.0.1:1337/v1
+JAN_ASSISTANT_API_KEY=your-api-key-here
+JAN_ASSISTANT_API_MODEL=qwen3:30b-a3b
+JAN_ASSISTANT_API_TIMEOUT=30
+
+# Security Settings
+JAN_ASSISTANT_SECURITY_ALLOWED_COMMANDS=["ls","pwd","cat","echo","python3"]
+JAN_ASSISTANT_SECURITY_MAX_FILE_SIZE=10MB
+
+# Development Settings
+JAN_ASSISTANT_DEBUG=false
+JAN_ASSISTANT_LOG_LEVEL=INFO
+
+# Memory Configuration
+JAN_ASSISTANT_MEMORY_FILE=data/memory.db
+JAN_ASSISTANT_MEMORY_MAX_ENTRIES=1000

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests>=2.31.0
 tkinter-tooltip>=2.1.0
 psutil>=5.8.0
+python-dotenv>=1.0.0

--- a/src/core/enhanced_config.py
+++ b/src/core/enhanced_config.py
@@ -1,0 +1,50 @@
+"""Enhanced configuration with environment support"""
+
+import os
+from pathlib import Path
+from dotenv import load_dotenv
+from typing import Any, Optional
+
+from .config import Config
+
+
+class EnhancedConfig(Config):
+    """Configuration with environment variable support"""
+
+    def __init__(self, config_path: Optional[str] = None, env_file: Optional[str] = None):
+        # Load environment variables
+        if env_file:
+            load_dotenv(env_file)
+        else:
+            env_path = Path(__file__).parent.parent / ".env"
+            if env_path.exists():
+                load_dotenv(env_path)
+        super().__init__(config_path=config_path)
+
+    def get(self, key_path: str, default: Any = None):
+        """Get config value with environment variable override"""
+        env_key = f"JAN_ASSISTANT_{key_path.replace('.', '_').upper()}"
+        env_value = os.getenv(env_key)
+        if env_value is not None:
+            return self._convert_env_value(env_value)
+        return super().get(key_path, default)
+
+    def _convert_env_value(self, value: str):
+        """Convert environment variable string to appropriate type"""
+        lower = value.lower()
+        if lower in ("true", "false"):
+            return lower == "true"
+        if value.isdigit() or (value.startswith("-") and value[1:].isdigit()):
+            return int(value)
+        try:
+            return float(value)
+        except ValueError:
+            pass
+        if value.startswith(("[", "{")):
+            try:
+                import json
+
+                return json.loads(value)
+            except json.JSONDecodeError:
+                pass
+        return value

--- a/src/core/enhanced_config.py
+++ b/src/core/enhanced_config.py
@@ -23,7 +23,7 @@ class EnhancedConfig(Config):
 
     def get(self, key_path: str, default: Any = None):
         """Get config value with environment variable override"""
-        env_key = f"JAN_ASSISTANT_{key_path.replace('.', '_').upper()}"
+        env_key = f"{ENV_PREFIX}{key_path.replace('.', '_').upper()}"
         env_value = os.getenv(env_key)
         if env_value is not None:
             return self._convert_env_value(env_value)

--- a/src/core/enhanced_config.py
+++ b/src/core/enhanced_config.py
@@ -14,11 +14,11 @@ class EnhancedConfig(Config):
     def __init__(self, config_path: Optional[str] = None, env_file: Optional[str] = None):
         # Load environment variables
         if env_file:
-            load_dotenv(env_file)
+            load_dotenv(env_file, override=True)
         else:
             env_path = Path(__file__).parent.parent / ".env"
             if env_path.exists():
-                load_dotenv(env_path)
+                load_dotenv(env_path, override=True)
         super().__init__(config_path=config_path)
 
     def get(self, key_path: str, default: Any = None):

--- a/tests/test_enhanced_config.py
+++ b/tests/test_enhanced_config.py
@@ -1,0 +1,25 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
+
+from core.enhanced_config import EnhancedConfig
+
+
+def test_env_override_int(tmp_path, monkeypatch):
+    config_file = tmp_path / "config.json"
+    config_file.write_text('{"api": {"timeout": 30}}')
+
+    monkeypatch.setenv("JAN_ASSISTANT_API_TIMEOUT", "45")
+    cfg = EnhancedConfig(config_path=str(config_file))
+    assert cfg.get("api.timeout") == 45
+
+
+def test_env_file_loading(tmp_path):
+    config_file = tmp_path / "config.json"
+    config_file.write_text('{"api": {"base_url": "http://default"}}')
+    env_file = tmp_path / ".env"
+    env_file.write_text("JAN_ASSISTANT_API_BASE_URL=http://envfile")
+
+    cfg = EnhancedConfig(config_path=str(config_file), env_file=str(env_file))
+    assert cfg.get("api.base_url") == "http://envfile"


### PR DESCRIPTION
## Summary
- add `python-dotenv` to requirements
- introduce `EnhancedConfig` supporting environment variables
- provide `.env.example` template for configuration
- test environment override and env file loading

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855cd9200d08328b5a44d7f36f76ccc