### PR TITLE
Update Ruff configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,10 @@ target-version = ["py38", "py39", "py310", "py311"]
 [tool.ruff]
 line-length = 88
 target-version = "py38"
+extend-select = ["I"]
+
+[tool.ruff.format]
+quote-style = "double"
 
 [tool.mypy]
 python_version = "3.8"


### PR DESCRIPTION
## Summary
- enable import ordering checks via `extend-select = ["I"]`
- configure Ruff formatter to use double quotes
- verify Ruff is included in dev dependencies

## Testing
- `poetry run pytest tests/ -v` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6855dc3342b48328bb152015136a74b8