### PR TITLE
Update Makefile formatting commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,14 +16,14 @@ test-watch:
 
 # Code quality
 lint:
-        ruff src/ tests/
+        ruff check src/ tests/
         mypy src/
 
 format:
-        black src/ tests/
+        ruff format src/ tests/
 
 format-check:
-        black --check src/ tests/
+        ruff format --check src/ tests/
 
 # Security check
 security:


### PR DESCRIPTION
## Summary
- use `ruff` for formatting tasks

## Testing
- `make format` *(fails: missing separator)*
- `make lint` *(fails: missing separator)*
- `pytest -q tests/test_api_client.py` *(fails: ModuleNotFoundError: requests)*

------
https://chatgpt.com/codex/tasks/task_e_6855de1a7d6483289f694e75777dac94