### PR TITLE
Replace Black docs with Ruff

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,7 @@ jan-assistant-pro/
 ### Code Style
 
 - **Python**: Follow PEP 8
-- **Line length**: 88 characters (Black formatter)
+- **Line length**: 88 characters (Ruff formatter)
 - **Imports**: Use absolute imports
 - **Docstrings**: Google style docstrings
 - **Type hints**: Use type hints where possible
@@ -339,7 +339,7 @@ Add any other context about the feature request.
 
 3. **Format code**
    ```bash
-   black src/ tests/
+   ruff format src/ tests/
    ruff src/ tests/
    ```
 
@@ -414,7 +414,7 @@ We follow [Semantic Versioning](https://semver.org/):
 
 ### Development Tools
 
-- **Code formatting**: [Black](https://black.readthedocs.io/)
+- **Code formatting**: [Ruff](https://docs.astral.sh/ruff/)
 - **Linting**: [ruff](https://docs.astral.sh/ruff/)
 - **Type checking**: [mypy](https://mypy.readthedocs.io/)
 - **Testing**: [pytest](https://docs.pytest.org/)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Python 3.8+](https://img.shields.io/badge/python-3.8+-blue.svg)](https://www.python.org/downloads/)
-[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
+[![Code style: ruff](https://img.shields.io/badge/code%20style-ruff-000000.svg)](https://docs.astral.sh/ruff/)
 [![Tests](https://img.shields.io/badge/tests-comprehensive-green.svg)](#testing)
 
 A **professional-grade**, local-first AI assistant with enterprise-ready architecture and extensible tool system that **works** with Jan.ai.
@@ -306,7 +306,7 @@ coverage html  # Creates htmlcov/ directory
 
 ```bash
 # Format code
-black src/ tests/
+ruff format src/ tests/
 
 # Check style
 ruff src/ tests/


### PR DESCRIPTION
## Summary
- update README formatting instructions to use Ruff instead of Black
- reference Ruff in CONTRIBUTING as the formatter

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError for requests and dotenv)*

------
https://chatgpt.com/codex/tasks/task_e_6855e09773cc8328b11bc0b49ea4b2b1