### PR TITLE
Fix f-string escaping in memory recall

### DIFF
--- a/src/core/app_controller.py
+++ b/src/core/app_controller.py
@@ -155,7 +155,7 @@ class AppController:
                 matches = self.memory_manager.fuzzy_recall(key)
                 if matches:
                     similar = [
-                        f"{k}: {v[\"value\"]}" for k, v in matches[:3]
+                        f"{k}: {v['value']}" for k, v in matches[:3]
                     ]
                     return (
                         "Found similar memories: " +


### PR DESCRIPTION
## Summary
- simplify f-string when formatting fuzzy memory recall

## Testing
- `python -m py_compile src/core/app_controller.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855e1c45a5083289e88ff763f951900