### PR TITLE
Add pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.4.4
+    hooks:
+      - id: ruff
+      - id: ruff-format
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.8.0
+    hooks:
+      - id: mypy
+        args: ["--install-types", "--non-interactive", "src"]

--- a/README.md
+++ b/README.md
@@ -95,7 +95,12 @@ poetry install --with dev
 
 # Run tests
 poetry run pytest tests/
+
+# Install git hooks
+pre-commit install
 ```
+Running this command sets up git hooks so Ruff and mypy run automatically
+before each commit.
 
 ## ⚙️ Configuration
 

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -67,7 +67,10 @@ graph TD
    git clone https://github.com/CreativeNewEra/jan-assistant-pro.git
    cd jan-assistant-pro
    poetry install --with dev
+   pre-commit install
    ```
+   This installs git hooks so formatting and type checks run automatically
+   before each commit.
 
 2. **Run tests to verify setup**:
    ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ pytest = "^7.0"
 black = "^23.0"
 ruff = "^0.4.4"
 mypy = "^1.0"
+pre-commit = "^3.5"
 
 [build-system]
 requires = ["poetry-core>=1.9.0"]


### PR DESCRIPTION
## Summary
- add `.pre-commit-config.yaml` using ruff and mypy
- include pre-commit in dev dependencies
- document pre-commit installation in README and developer guide

## Testing
- `ruff check src tests`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6855e3110f6c8328b0425b2949078034