### PR TITLE
Organize Python imports

### DIFF
--- a/examples/jan_gui_fixed.py
+++ b/examples/jan_gui_fixed.py
@@ -1,11 +1,12 @@
-import tkinter as tk
-from tkinter import messagebox, filedialog
-import requests
+from datetime import datetime
 import json
 import os
 import subprocess
-from datetime import datetime
 import threading
+import tkinter as tk
+from tkinter import messagebox, filedialog
+
+import requests
 
 class JanAssistantGUI:
     def __init__(self):

--- a/jan_simple_gui.py
+++ b/jan_simple_gui.py
@@ -1,7 +1,6 @@
 import tkinter as tk
-from tkinter import messagebox
+
 import requests
-import json
 
 class SimpleJanGUI:
     def __init__(self):

--- a/main.py
+++ b/main.py
@@ -4,8 +4,8 @@ Jan Assistant Pro
 A powerful local-first AI assistant with tools
 """
 
-import sys
 import os
+import sys
 import tkinter as tk
 from tkinter import messagebox
 
@@ -13,8 +13,8 @@ from tkinter import messagebox
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'src'))
 
 try:
-    from gui.main_window import JanAssistantGUI
-    from core.config import Config
+    from src.gui.main_window import JanAssistantGUI
+    from src.core.config import Config
 except ImportError as e:
     print(f"Import error: {e}")
     print("Please ensure all dependencies are installed: poetry install")

--- a/src/core/app_controller.py
+++ b/src/core/app_controller.py
@@ -3,13 +3,13 @@ Application Controller for Jan Assistant Pro
 Handles the main application logic, decoupling it from the GUI.
 """
 
-from typing import Dict, Any, List
+from typing import Any, Dict, List
 
-from core.config import Config
-from core.api_client import APIClient, APIError
-from core.memory import MemoryManager
-from tools.file_tools import FileTools
-from tools.system_tools import SystemTools
+from src.core.config import Config
+from src.core.api_client import APIClient, APIError
+from src.core.memory import MemoryManager
+from src.tools.file_tools import FileTools
+from src.tools.system_tools import SystemTools
 
 
 class AppController:

--- a/src/core/config_validator.py
+++ b/src/core/config_validator.py
@@ -3,13 +3,13 @@ Configuration validation for Jan Assistant Pro
 Provides schema-based validation and type safety for configuration
 """
 
+from dataclasses import dataclass, field
 import json
 import os
-from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Type, Union
 
-from .exceptions import ConfigurationError, ValidationError
+from src.core.exceptions import ConfigurationError, ValidationError
 
 
 @dataclass

--- a/src/core/enhanced_config.py
+++ b/src/core/enhanced_config.py
@@ -6,9 +6,9 @@ from typing import Any, Optional
 
 from dotenv import load_dotenv
 
-ENV_PREFIX = "JAN_ASSISTANT_"
+from src.core.config import Config
 
-from .config import Config
+ENV_PREFIX = "JAN_ASSISTANT_"
 
 
 class EnhancedConfig(Config):

--- a/src/core/logging_config.py
+++ b/src/core/logging_config.py
@@ -3,12 +3,12 @@ Logging configuration for Jan Assistant Pro
 Provides structured logging with multiple outputs and levels
 """
 
+from datetime import datetime
 import json
 import logging
 import logging.handlers
 import os
 import sys
-from datetime import datetime
 from typing import Any, Dict, Optional
 
 

--- a/src/core/memory.py
+++ b/src/core/memory.py
@@ -2,13 +2,13 @@
 Memory management system for Jan Assistant Pro
 """
 
-import json
-import os
-import sqlite3
-import threading
 from contextlib import contextmanager
 from datetime import datetime
+import json
+import os
 from pathlib import Path
+import sqlite3
+import threading
 from typing import Any, Dict, List, Optional, Tuple
 
 

--- a/src/gui/__init__.py
+++ b/src/gui/__init__.py
@@ -1,3 +1,3 @@
-from .enhanced_widgets import ChatInput, EnhancedChatDisplay, StatusBar
+from src.gui.enhanced_widgets import ChatInput, EnhancedChatDisplay, StatusBar
 
 __all__ = ["StatusBar", "ChatInput", "EnhancedChatDisplay"]

--- a/src/gui/enhanced_widgets.py
+++ b/src/gui/enhanced_widgets.py
@@ -1,7 +1,7 @@
 """GUI widget enhancements for Jan Assistant Pro."""
 
-import tkinter as tk
 from datetime import datetime
+import tkinter as tk
 from tkinter import ttk
 
 

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -9,11 +9,9 @@ import tkinter as tk
 from tkinter import filedialog, messagebox
 from typing import Any, Dict
 
-from core.app_controller import AppController
-
-# Import our core modules
-from core.config import Config
-from gui.enhanced_widgets import ChatInput, EnhancedChatDisplay, StatusBar
+from src.core.app_controller import AppController
+from src.core.config import Config
+from src.gui.enhanced_widgets import ChatInput, EnhancedChatDisplay, StatusBar
 
 
 class JanAssistantGUI:

--- a/src/tools/base_tool.py
+++ b/src/tools/base_tool.py
@@ -3,9 +3,9 @@ Base tool interface for Jan Assistant Pro
 Provides the foundation for the dynamic tool registry system
 """
 
-import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
+import logging
 from typing import Any, Dict, List, Optional
 
 

--- a/src/tools/file_tools.py
+++ b/src/tools/file_tools.py
@@ -3,8 +3,8 @@ File operation tools for Jan Assistant Pro
 """
 
 import os
-import shutil
 from pathlib import Path
+import shutil
 from typing import Any, Dict, List, Optional
 
 

--- a/src/tools/tool_registry.py
+++ b/src/tools/tool_registry.py
@@ -3,12 +3,12 @@ Dynamic tool registry system for Jan Assistant Pro
 Manages registration, discovery, and execution of tools
 """
 
+from collections import defaultdict
 import inspect
 import logging
-from collections import defaultdict
 from typing import Any, Dict, List, Optional, Set, Type
 
-from .base_tool import BaseTool, ToolInfo
+from src.tools.base_tool import BaseTool, ToolInfo
 
 
 class ToolRegistryError(Exception):

--- a/tests/test_enhanced_config.py
+++ b/tests/test_enhanced_config.py
@@ -3,7 +3,7 @@ import sys
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
 
-from core.enhanced_config import EnhancedConfig
+from src.core.enhanced_config import EnhancedConfig
 
 
 def test_env_override_int(tmp_path, monkeypatch):

--- a/tests/test_enhanced_features.py
+++ b/tests/test_enhanced_features.py
@@ -5,23 +5,20 @@ Tests the new tool registry, error handling, and configuration validation
 
 import json
 import os
-
-# Import the modules we're testing
 import sys
 import tempfile
-import unittest
 from typing import Any, Dict
-from unittest.mock import MagicMock, Mock, patch
+import unittest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
 
-from core.config_validator import (
+from src.core.config_validator import (
     ConfigSchema,
     ConfigValidator,
     ValidationRule,
     create_jan_assistant_schema,
 )
-from core.exceptions import (
+from src.core.exceptions import (
     APIError,
     ConfigurationError,
     JanAssistantError,
@@ -29,8 +26,8 @@ from core.exceptions import (
     ValidationError,
     handle_exception,
 )
-from tools.base_tool import BaseTool, ToolInfo, ToolParameter
-from tools.tool_registry import ToolRegistry, ToolRegistryError
+from src.tools.base_tool import BaseTool, ToolInfo, ToolParameter
+from src.tools.tool_registry import ToolRegistry, ToolRegistryError
 
 
 class MockTool(BaseTool):

--- a/tests/test_enhanced_memory_manager.py
+++ b/tests/test_enhanced_memory_manager.py
@@ -3,7 +3,7 @@ import sys
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
 
-from core.memory import EnhancedMemoryManager
+from src.core.memory import EnhancedMemoryManager
 
 
 def test_sqlite_persistence(tmp_path):

--- a/tests/test_file_tools.py
+++ b/tests/test_file_tools.py
@@ -1,5 +1,3 @@
-import os
-
 from src.tools.file_tools import FileTools
 
 

--- a/tests/test_gui_widgets.py
+++ b/tests/test_gui_widgets.py
@@ -1,12 +1,11 @@
 import os
 import sys
+import tkinter as tk
 import unittest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src')))
 
-import tkinter as tk
-
-from gui.enhanced_widgets import ChatInput, StatusBar
+from src.gui.enhanced_widgets import ChatInput, StatusBar
 
 
 def create_root_or_skip():

--- a/tests/test_memory_manager.py
+++ b/tests/test_memory_manager.py
@@ -1,10 +1,9 @@
 import os
 import sys
-import tempfile
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
 
-from core.memory import MemoryManager
+from src.core.memory import MemoryManager
 
 
 def test_memory_persistence(tmp_path):


### PR DESCRIPTION
## Summary
- reorder imports following PEP8 group ordering
- switch to absolute imports for local modules
- drop unused imports

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855e59de61c8328866e79fa8e0d08d5