### PR TITLE
Add UnifiedConfig with env and schema support

### DIFF
--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -315,21 +315,23 @@ poetry run pytest tests/ -k "test_weather" -v
 
 ### Schema-Based Validation
 
-Configuration is validated using schemas defined in `config_validator.py`:
+Configuration is validated and loaded through `UnifiedConfig`, which
+combines schema validation and environment variable support:
 
 ```python
-from core.config_validator import ConfigValidator, ValidationRule
+from core.unified_config import UnifiedConfig
+from core.config_validator import ValidationRule
 
 # Create custom validation rules
-validator = ConfigValidator()
-validator.schema.add_rule('my_tool.api_key', ValidationRule(
+cfg = UnifiedConfig('config.json')
+cfg.validator.schema.add_rule('my_tool.api_key', ValidationRule(
     field_type=str,
     required=True,
     description="API key for my tool"
 ))
 
 # Validate configuration
-config = validator.validate_config_file('config.json')
+config = cfg.config_data
 ```
 
 ### Configuration Structure

--- a/src/core/unified_config.py
+++ b/src/core/unified_config.py
@@ -1,0 +1,206 @@
+"""Unified configuration system for Jan Assistant Pro"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from dotenv import load_dotenv
+
+from .config_validator import ConfigValidator
+from .logging_config import get_logger
+
+ENV_PREFIX = "JAN_ASSISTANT_"
+
+
+class UnifiedConfig:
+    """Configuration manager with validation and env overrides."""
+
+    def __init__(
+        self,
+        config_path: Optional[str] = None,
+        env_file: Optional[str] = None,
+        schema: Optional[ConfigValidator] = None,
+    ) -> None:
+        if env_file:
+            load_dotenv(env_file, override=True)
+        else:
+            env_path = Path(__file__).parent.parent / ".env"
+            if env_path.exists():
+                load_dotenv(env_path, override=True)
+
+        self.config_path = config_path or self._find_config_path()
+        self.logger = get_logger(
+            f"{self.__class__.__module__}.{self.__class__.__name__}",
+            {"config_path": self.config_path},
+        )
+        self.validator = schema or ConfigValidator()
+        self.config_data: Dict[str, Any] = {}
+        self.reload()
+
+    def _find_config_path(self) -> str:
+        possible_paths = [
+            os.path.join(os.getcwd(), "config", "config.json"),
+            os.path.join(Path(__file__).resolve().parent.parent, "config", "config.json"),
+            os.path.expanduser("~/.jan-assistant-pro/config.json"),
+        ]
+        for path in possible_paths:
+            if os.path.exists(path):
+                return path
+        return possible_paths[0]
+
+    def _ensure_config_dir(self) -> None:
+        config_dir = os.path.dirname(self.config_path)
+        os.makedirs(config_dir, exist_ok=True)
+
+    def _get_default_config(self) -> Dict[str, Any]:
+        return {
+            "api": {
+                "base_url": "http://127.0.0.1:1337/v1",
+                "api_key": "124578",
+                "model": "qwen3:30b-a3b",
+                "timeout": 30,
+            },
+            "memory": {
+                "file": "data/memory.json",
+                "max_entries": 1000,
+                "auto_save": True,
+            },
+            "ui": {
+                "theme": "dark",
+                "window_size": "800x600",
+                "font_family": "Consolas",
+                "font_size": 10,
+            },
+            "tools": {
+                "file_operations": True,
+                "system_commands": True,
+                "memory_operations": True,
+                "web_search": False,
+            },
+            "security": {
+                "allowed_commands": [
+                    "ls",
+                    "pwd",
+                    "cat",
+                    "echo",
+                    "python3",
+                    "python",
+                    "ping",
+                ],
+                "restricted_paths": ["/etc", "/sys", "/proc"],
+                "max_file_size": "10MB",
+            },
+        }
+
+    # ------------------------------------------------------------------
+    # Loading and validation
+    # ------------------------------------------------------------------
+    def reload(self) -> None:
+        self.config_data = self._load_config()
+
+    def _load_config(self) -> Dict[str, Any]:
+        if os.path.exists(self.config_path):
+            try:
+                with open(self.config_path, "r", encoding="utf-8") as f:
+                    data = json.load(f)
+            except (json.JSONDecodeError, OSError) as e:
+                self.logger.warning(
+                    "Could not load config file",
+                    extra={"extra_fields": {"error": str(e), "path": self.config_path}},
+                )
+                data = self._get_default_config()
+        else:
+            data = self._get_default_config()
+            self._ensure_config_dir()
+            self.save_config(data)
+
+        data = self._apply_env_overrides(data)
+        return self.validator.validate_config_data(data)
+
+    def _apply_env_overrides(self, config_data: Dict[str, Any]) -> Dict[str, Any]:
+        for field_path in self.validator.schema.rules.keys():
+            env_key = ENV_PREFIX + field_path.replace(".", "_").upper()
+            if env_key in os.environ:
+                value = self._convert_env_value(os.environ[env_key])
+                self._set_nested_value(config_data, field_path, value)
+        return config_data
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    def _convert_env_value(self, value: str) -> Any:
+        lower = value.lower()
+        if lower in ("true", "false"):
+            return lower == "true"
+        if value.isdigit() or (value.startswith("-") and value[1:].isdigit()):
+            return int(value)
+        try:
+            return float(value)
+        except ValueError:
+            pass
+        if value.startswith("[") or value.startswith("{"):
+            try:
+                return json.loads(value)
+            except json.JSONDecodeError:
+                pass
+        return value
+
+    def _set_nested_value(self, data: Dict[str, Any], path: str, value: Any) -> None:
+        keys = path.split(".")
+        current = data
+        for key in keys[:-1]:
+            if key not in current or not isinstance(current[key], dict):
+                current[key] = {}
+            current = current[key]
+        current[keys[-1]] = value
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def get(self, key_path: str, default: Any = None) -> Any:
+        keys = key_path.split(".")
+        value: Any = self.config_data
+        for key in keys:
+            if isinstance(value, dict) and key in value:
+                value = value[key]
+            else:
+                return default
+        return value
+
+    def set(self, key_path: str, value: Any) -> None:
+        self._set_nested_value(self.config_data, key_path, value)
+
+    def save_config(self, config_data: Optional[Dict[str, Any]] = None) -> None:
+        data = config_data or self.config_data
+        self._ensure_config_dir()
+        tmp_path = self.config_path + ".tmp"
+        backup_path = self.config_path + ".bak"
+        try:
+            with open(tmp_path, "w", encoding="utf-8") as f:
+                json.dump(data, f, indent=2)
+            if os.path.exists(self.config_path):
+                shutil.copy2(self.config_path, backup_path)
+            os.replace(tmp_path, self.config_path)
+        except OSError as e:
+            self.logger.warning(
+                "Could not save config file",
+                extra={"extra_fields": {"error": str(e), "path": self.config_path}},
+            )
+            if os.path.exists(backup_path):
+                shutil.copy2(backup_path, self.config_path)
+            raise
+
+    def restore_backup(self) -> bool:
+        backup_path = self.config_path + ".bak"
+        if os.path.exists(backup_path):
+            shutil.copy2(backup_path, self.config_path)
+            self.reload()
+            return True
+        return False
+
+    def __str__(self) -> str:
+        return f"UnifiedConfig(path={self.config_path})"

--- a/tests/test_enhanced_config.py
+++ b/tests/test_enhanced_config.py
@@ -3,23 +3,27 @@ import sys
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
 
-from src.core.enhanced_config import EnhancedConfig
+from src.core.unified_config import UnifiedConfig
 
 
 def test_env_override_int(tmp_path, monkeypatch):
     config_file = tmp_path / "config.json"
-    config_file.write_text('{"api": {"timeout": 30}}')
+    config_file.write_text(
+        '{"api": {"base_url": "http://a", "api_key": "k", "model": "m", "timeout": 30}, "memory": {"file": "mem"}}'
+    )
 
     monkeypatch.setenv("JAN_ASSISTANT_API_TIMEOUT", "45")
-    cfg = EnhancedConfig(config_path=str(config_file))
+    cfg = UnifiedConfig(config_path=str(config_file))
     assert cfg.get("api.timeout") == 45
 
 
 def test_env_file_loading(tmp_path):
     config_file = tmp_path / "config.json"
-    config_file.write_text('{"api": {"base_url": "http://default"}}')
+    config_file.write_text(
+        '{"api": {"base_url": "http://default", "api_key": "k", "model": "m"}, "memory": {"file": "mem"}}'
+    )
     env_file = tmp_path / ".env"
     env_file.write_text("JAN_ASSISTANT_API_BASE_URL=http://envfile")
 
-    cfg = EnhancedConfig(config_path=str(config_file), env_file=str(env_file))
+    cfg = UnifiedConfig(config_path=str(config_file), env_file=str(env_file))
     assert cfg.get("api.base_url") == "http://envfile"

--- a/tests/test_system_tools.py
+++ b/tests/test_system_tools.py
@@ -1,6 +1,6 @@
 from unittest.mock import patch
 
-from src.core.config import Config
+from src.core.unified_config import UnifiedConfig
 from src.tools.system_tools import SystemTools
 
 
@@ -46,7 +46,7 @@ def test_check_network_connectivity_failure_result_error():
 
 
 def test_check_network_connectivity_with_default_config(tmp_path):
-    cfg = Config(config_path=str(tmp_path / "config.json"))
+    cfg = UnifiedConfig(config_path=str(tmp_path / "config.json"))
     tools = SystemTools(allowed_commands=cfg.get("security.allowed_commands"))
     assert "ping" in tools.allowed_commands
     mock_result = {'success': True, 'return_code': 0, 'stdout': 'ok', 'stderr': ''}


### PR DESCRIPTION
## Summary
- implement `UnifiedConfig` providing environment variable overrides, schema-based validation and atomic saving
- adjust tests to use new configuration class
- document unified config usage in developer guide

## Testing
- `ruff check tests/test_enhanced_config.py tests/test_system_tools.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855ead040348328a7e054ef2b10b50e