### PR TITLE
Add aiohttp-based async API client

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ python-dotenv = ">=1.0.0"
 psutil = { version = ">=5.8.0", optional = true }
 orjson = { version = ">=3.8.0", optional = true }
 httpx = { version = ">=0.25.0", optional = true }
+aiohttp = "^3.9"
 
 [tool.poetry.extras]
 system = ["psutil"]
@@ -23,6 +24,7 @@ black = "^23.0"
 ruff = "^0.4.4"
 mypy = "^1.0"
 pre-commit = "^3.5"
+pytest-asyncio = "^0.23"
 
 [build-system]
 requires = ["poetry-core>=1.9.0"]

--- a/src/core/async_api_client.py
+++ b/src/core/async_api_client.py
@@ -1,0 +1,174 @@
+"""Asynchronous API client for Jan Assistant Pro"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict, List, Optional
+
+import aiohttp
+
+from .exceptions import APIError
+
+
+class AsyncAPIClient:
+    """Async client for interacting with OpenAI-compatible APIs."""
+
+    def __init__(self, base_url: str, api_key: str, model: str, timeout: int = 30):
+        self.base_url = base_url.rstrip("/")
+        self.api_key = api_key
+        self.model = model
+        self.timeout = timeout
+        self.session: Optional[aiohttp.ClientSession] = None
+
+    async def __aenter__(self) -> "AsyncAPIClient":
+        if self.session is None or self.session.closed:
+            connector = aiohttp.TCPConnector(limit=100, force_close=False)
+            headers = {
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {self.api_key}",
+            }
+            self.session = aiohttp.ClientSession(
+                connector=connector,
+                headers=headers,
+            )
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        if self.session and not self.session.closed:
+            await self.session.close()
+        self.session = None
+
+    async def _ensure_session(self) -> aiohttp.ClientSession:
+        if self.session is None or self.session.closed:
+            await self.__aenter__()
+        assert self.session is not None
+        return self.session
+
+    async def chat_completion(
+        self,
+        messages: List[Dict[str, str]],
+        stream: bool = False,
+        temperature: float = 0.7,
+        max_tokens: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        """Send an async chat completion request."""
+        session = await self._ensure_session()
+        url = f"{self.base_url}/chat/completions"
+
+        payload: Dict[str, Any] = {
+            "model": self.model,
+            "messages": messages,
+            "stream": stream,
+            "temperature": temperature,
+        }
+        if max_tokens is not None:
+            payload["max_tokens"] = max_tokens
+
+        try:
+            async with session.post(url, json=payload, timeout=self.timeout) as resp:
+                try:
+                    resp.raise_for_status()
+                except aiohttp.ClientResponseError:
+                    error_detail = ""
+                    try:
+                        error_json = await resp.json()
+                        error_detail = error_json.get("message", "")
+                    except Exception:
+                        pass
+
+                    if resp.status == 400:
+                        if "Engine is not loaded" in error_detail:
+                            raise APIError(
+                                "Model is not loaded in Jan. Please start your model first."
+                            )
+                        raise APIError(f"Bad request: {error_detail}")
+                    if resp.status == 401:
+                        raise APIError("Authentication failed. Check your API key.")
+                    if resp.status == 404:
+                        raise APIError("API endpoint not found. Check your base URL.")
+                    raise APIError(f"HTTP {resp.status}: {error_detail}")
+
+                return await resp.json()
+        except asyncio.TimeoutError as exc:
+            raise APIError("Request timed out") from exc
+        except aiohttp.ClientError as exc:
+            raise APIError("Could not connect to API server. Is Jan running?") from exc
+        except Exception as exc:
+            raise APIError(f"Unexpected error: {exc}") from exc
+
+    async def get_models(self) -> List[Dict[str, Any]]:
+        """Get list of available models."""
+        session = await self._ensure_session()
+        url = f"{self.base_url}/models"
+
+        try:
+            async with session.get(url, timeout=self.timeout) as resp:
+                resp.raise_for_status()
+                data = await resp.json()
+                return data.get("data", [])
+        except asyncio.TimeoutError as exc:
+            raise APIError("Request timed out") from exc
+        except aiohttp.ClientError as exc:
+            raise APIError("Failed to get models: network error") from exc
+        except Exception as exc:
+            raise APIError(f"Failed to get models: {exc}") from exc
+
+    async def health_check(self) -> bool:
+        """Check if the API is healthy."""
+        try:
+            await self.chat_completion([{"role": "user", "content": "hi"}])
+            return True
+        except APIError:
+            return False
+        except Exception:
+            return False
+
+    async def test_connection(self) -> Dict[str, Any]:
+        """Test connection and return status information."""
+        status = {
+            "connected": False,
+            "model_loaded": False,
+            "latency_ms": None,
+            "error": None,
+        }
+
+        try:
+            start = asyncio.get_event_loop().time()
+            response = await self.chat_completion([{"role": "user", "content": "ping"}])
+            end = asyncio.get_event_loop().time()
+            status["latency_ms"] = round((end - start) * 1000, 2)
+            status["connected"] = True
+            status["model_loaded"] = True
+        except APIError as exc:
+            status["error"] = str(exc)
+            if "not loaded" in str(exc).lower():
+                status["connected"] = True
+        except Exception as exc:
+            status["error"] = f"Connection failed: {exc}"
+        return status
+
+    @staticmethod
+    def extract_content(response: Dict[str, Any]) -> str:
+        """Extract text content from chat completion response."""
+        try:
+            return response["choices"][0]["message"]["content"]
+        except (KeyError, IndexError) as exc:
+            raise APIError("Invalid response format: missing content") from exc
+
+    @staticmethod
+    def extract_reasoning(response: Dict[str, Any]) -> Optional[str]:
+        """Extract reasoning content if available."""
+        try:
+            return response["choices"][0]["message"].get("reasoning_content")
+        except (KeyError, IndexError):
+            return None
+
+    @staticmethod
+    def get_usage_stats(response: Dict[str, Any]) -> Dict[str, int]:
+        """Extract usage statistics from response."""
+        usage = response.get("usage", {})
+        return {
+            "prompt_tokens": usage.get("prompt_tokens", 0),
+            "completion_tokens": usage.get("completion_tokens", 0),
+            "total_tokens": usage.get("total_tokens", 0),
+        }

--- a/tests/test_async_api_client.py
+++ b/tests/test_async_api_client.py
@@ -1,0 +1,78 @@
+from unittest.mock import AsyncMock, Mock, patch
+
+import asyncio
+import pytest
+import aiohttp
+
+from src.core.async_api_client import AsyncAPIClient
+from src.core.exceptions import APIError
+
+
+def _create_client():
+    return AsyncAPIClient(base_url="http://test", api_key="key", model="model")
+
+
+@pytest.mark.asyncio
+async def test_chat_completion_success():
+    client = _create_client()
+    messages = [{"role": "user", "content": "hi"}]
+    async with client:
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(
+            return_value={"choices": [{"message": {"content": "hello"}}]}
+        )
+        mock_resp.raise_for_status = Mock()
+        mock_cm = AsyncMock()
+        mock_cm.__aenter__.return_value = mock_resp
+        mock_cm.__aexit__.return_value = None
+        with patch.object(client.session, "post", return_value=mock_cm) as post:
+            response = await client.chat_completion(messages)
+            post.assert_called_once()
+            mock_resp.raise_for_status.assert_called_once()
+    assert response["choices"][0]["message"]["content"] == "hello"
+
+
+@pytest.mark.asyncio
+async def test_chat_completion_timeout():
+    client = _create_client()
+    messages = [{"role": "user", "content": "hi"}]
+    async with client:
+        with patch.object(client.session, "post", side_effect=asyncio.TimeoutError):
+            with pytest.raises(APIError):
+                await client.chat_completion(messages)
+
+
+@pytest.mark.asyncio
+async def test_chat_completion_client_error():
+    client = _create_client()
+    messages = [{"role": "user", "content": "hi"}]
+    async with client:
+        with patch.object(client.session, "post", side_effect=aiohttp.ClientError):
+            with pytest.raises(APIError):
+                await client.chat_completion(messages)
+
+
+@pytest.mark.asyncio
+async def test_get_models_success():
+    client = _create_client()
+    async with client:
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(return_value={"data": [{"id": "1"}]})
+        mock_resp.raise_for_status = Mock()
+        mock_cm = AsyncMock()
+        mock_cm.__aenter__.return_value = mock_resp
+        mock_cm.__aexit__.return_value = None
+        with patch.object(client.session, "get", return_value=mock_cm) as get:
+            models = await client.get_models()
+            get.assert_called_once()
+    assert models == [{"id": "1"}]
+
+
+@pytest.mark.asyncio
+async def test_health_check_failure():
+    client = _create_client()
+    with patch.object(client, "chat_completion", side_effect=APIError("fail")):
+        result = await client.health_check()
+    assert result is False


### PR DESCRIPTION
## Summary
- add `aiohttp` and `pytest-asyncio` dependencies
- implement `AsyncAPIClient` for asynchronous API access
- test async client behavior with success and error scenarios

## Testing
- `pip install aiohttp`
- `pip install pytest-asyncio`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855ee8a29f08328a264961012c275b2