### PR TITLE
Improve FileTools atomic writes

### DIFF
--- a/src/tools/file_tools.py
+++ b/src/tools/file_tools.py
@@ -164,6 +164,9 @@ class FileTools:
                     tmp.flush()
                     os.fsync(tmp.fileno())
                 os.replace(tmp_file, file_path)
+                # Preserve metadata if the original file existed
+                if file_existed:
+                    shutil.copystat(tmp_file, file_path)
             finally:
                 if tmp_file and os.path.exists(tmp_file):
                     os.remove(tmp_file)


### PR DESCRIPTION
## Summary
- ensure file writes are atomic
- use temp file when appending
- test atomic write and append behavior

## Testing
- `ruff check src/tools/file_tools.py tests/test_file_tools.py`
- `mypy src` *(fails: 97 errors)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855f3b37ae88328b9cfe7d19542a30c