### PR TITLE
Add context manager support for API clients

### DIFF
--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -1,4 +1,4 @@
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -11,35 +11,36 @@ def _create_client():
 
 
 def test_chat_completion_success():
-    client = _create_client()
     messages = [{"role": "user", "content": "hi"}]
-    async_mock = AsyncMock(
-        return_value={"choices": [{"message": {"content": "hello"}}]}
-    )
-    with patch.object(client._async_client, "chat_completion", async_mock):
-        response = client.chat_completion(messages)
-        async_mock.assert_awaited_once_with(
-            messages, stream=False, temperature=0.7, max_tokens=None
-        )
-    assert response["choices"][0]["message"]["content"] == "hello"
-    assert client.extract_content(response) == "hello"
+    async_mock = AsyncMock(return_value={"choices": [{"message": {"content": "hello"}}]})
+    with _create_client() as client:
+        with patch.object(client._async_client, "chat_completion", async_mock):
+            response = client.chat_completion(messages)
+            async_mock.assert_awaited_once_with(
+                messages, stream=False, temperature=0.7, max_tokens=None
+            )
+        assert response["choices"][0]["message"]["content"] == "hello"
+        assert client.extract_content(response) == "hello"
+    assert client._async_client.session is None
 
 
 def test_chat_completion_model_not_loaded():
-    client = _create_client()
     messages = [{"role": "user", "content": "hi"}]
     async_mock = AsyncMock(side_effect=APIError("Model is not loaded"))
-    with patch.object(client._async_client, "chat_completion", async_mock):
-        with pytest.raises(APIError) as exc:
-            client.chat_completion(messages)
-    assert "Model is not loaded" in str(exc.value)
+    with _create_client() as client:
+        with patch.object(client._async_client, "chat_completion", async_mock):
+            with pytest.raises(APIError) as exc:
+                client.chat_completion(messages)
+        assert "Model is not loaded" in str(exc.value)
+    assert client._async_client.session is None
 
 
 def test_chat_completion_connection_error():
-    client = _create_client()
     messages = [{"role": "user", "content": "hi"}]
     async_mock = AsyncMock(side_effect=APIError("Could not connect"))
-    with patch.object(client._async_client, "chat_completion", async_mock):
-        with pytest.raises(APIError) as exc:
-            client.chat_completion(messages)
-    assert "Could not connect" in str(exc.value)
+    with _create_client() as client:
+        with patch.object(client._async_client, "chat_completion", async_mock):
+            with pytest.raises(APIError) as exc:
+                client.chat_completion(messages)
+        assert "Could not connect" in str(exc.value)
+    assert client._async_client.session is None


### PR DESCRIPTION
## Summary
- add async context manager support in `AsyncAPIClient`
- allow `APIClient` to be used as a context manager
- update unit tests to use new context manager

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855f3c517a0832896cf8202c752af22