### PR TITLE
Add context manager cleanup to SecureCommandExecutor

### DIFF
--- a/src/tools/file_tools.py
+++ b/src/tools/file_tools.py
@@ -164,9 +164,6 @@ class FileTools:
                     tmp.flush()
                     os.fsync(tmp.fileno())
                 os.replace(tmp_file, file_path)
-                # Preserve metadata if the original file existed
-                if file_existed:
-                    shutil.copystat(tmp_file, file_path)
             finally:
                 if tmp_file and os.path.exists(tmp_file):
                     os.remove(tmp_file)

--- a/tests/test_secure_command_executor.py
+++ b/tests/test_secure_command_executor.py
@@ -1,36 +1,40 @@
+import os
+
 from src.tools.secure_command_executor import SecureCommandExecutor
 
 
 def test_allowed_command(tmp_path):
-    executor = SecureCommandExecutor(allowed_commands=["echo"])
-    result = executor.execute("echo hello", work_dir=str(tmp_path))
-    assert result["success"] is True
-    assert "hello" in result["stdout"]
+    with SecureCommandExecutor(allowed_commands=["echo"]) as executor:
+        result = executor.execute("echo hello", work_dir=str(tmp_path))
+        assert result["success"] is True
+        assert "hello" in result["stdout"]
 
 
 def test_blocked_command():
-    executor = SecureCommandExecutor(allowed_commands=["echo"], blocked_commands=["rm"])
-    result = executor.execute("rm -rf /tmp")
-    assert result["success"] is False
-    assert "blocked" in result["error"]
+    with SecureCommandExecutor(
+        allowed_commands=["echo"], blocked_commands=["rm"]
+    ) as executor:
+        result = executor.execute("rm -rf /tmp")
+        assert result["success"] is False
+        assert "blocked" in result["error"]
 
 
 def test_dangerous_pattern():
-    executor = SecureCommandExecutor(allowed_commands=["echo"])
-    result = executor.execute("echo hi && echo bye")
-    assert result["success"] is False
-    assert "dangerous" in result["error"]
+    with SecureCommandExecutor(allowed_commands=["echo"]) as executor:
+        result = executor.execute("echo hi && echo bye")
+        assert result["success"] is False
+        assert "dangerous" in result["error"]
 
 
 def test_output_truncation(tmp_path):
-    executor = SecureCommandExecutor(
+    with SecureCommandExecutor(
         allowed_commands=["python3"], max_output_bytes=50
-    )
-    cmd = "python3 -c 'print(\"x\"*200)'"
-    result = executor.execute(cmd, work_dir=str(tmp_path))
-    assert result["success"] is True
-    assert len(result["stdout"].encode()) <= 50
-    assert "truncated" in result.get("note", "")
+    ) as executor:
+        cmd = "python3 -c 'print(\"x\"*200)'"
+        result = executor.execute(cmd, work_dir=str(tmp_path))
+        assert result["success"] is True
+        assert len(result["stdout"].encode()) <= 50
+        assert "truncated" in result.get("note", "")
 
 
 def test_working_dir_isolation(tmp_path):
@@ -41,11 +45,25 @@ def test_working_dir_isolation(tmp_path):
     inside = sandbox / "inside.txt"
     inside.write_text("safe")
 
-    executor = SecureCommandExecutor(allowed_commands=["cat"], work_dir=str(sandbox))
-    ok = executor.execute("cat inside.txt", work_dir=str(sandbox))
-    assert ok["success"] is True
-    assert "safe" in ok["stdout"]
+    with SecureCommandExecutor(
+        allowed_commands=["cat"], work_dir=str(sandbox)
+    ) as executor:
+        ok = executor.execute("cat inside.txt", work_dir=str(sandbox))
+        assert ok["success"] is True
+        assert "safe" in ok["stdout"]
 
-    bad = executor.execute("cat ../outside.txt", work_dir=str(sandbox))
-    assert bad["success"] is False
-    assert "Path traversal" in bad["error"]
+        bad = executor.execute("cat ../outside.txt", work_dir=str(sandbox))
+        assert bad["success"] is False
+        assert "Path traversal" in bad["error"]
+
+
+def test_cleanup_after_context():
+    with SecureCommandExecutor(allowed_commands=["echo"]) as executor:
+        result = executor.execute("echo hi")
+        exec_dir = result["working_dir"]
+        base_dir = executor.base_work_dir
+        # execution directory should be removed immediately
+        assert not os.path.exists(exec_dir)
+        assert os.path.exists(base_dir)
+    # after context exit, base directory should be removed
+    assert not os.path.exists(base_dir)


### PR DESCRIPTION
## Summary
- use `tempfile.TemporaryDirectory` for SecureCommandExecutor work dirs
- add `__enter__`/`__exit__` methods for cleanup
- create execution directories with TemporaryDirectory and remove them
- update SecureCommandExecutor tests to verify cleanup
- remove broken metadata preservation in FileTools

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855f656e23c8328b8e034550bce2da9