### PR TITLE
Add cache helpers and integrate caching

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ orjson = { version = ">=3.8.0", optional = true }
 httpx = { version = ">=0.25.0", optional = true }
 aiohttp = "^3.9"
 prometheus-client = ">=0.22"
+cachetools = ">=5.3"
 
 [tool.poetry.extras]
 system = ["psutil"]

--- a/src/core/cache.py
+++ b/src/core/cache.py
@@ -65,9 +65,10 @@ class DiskCache:
             try:
                 with open(path, "rb") as f:
                     data = pickle.load(f)
-            except Exception:
-                # Corrupt cache; remove it
+            except (pickle.UnpicklingError, OSError) as e:
+                # Corrupt cache; remove it and log the error
                 path.unlink(missing_ok=True)
+                print(f"Warning: Corrupted cache file {path} removed. Error: {e}")
                 return None
         if data.get("expires_at", 0) < time.time():
             path.unlink(missing_ok=True)

--- a/src/core/cache.py
+++ b/src/core/cache.py
@@ -1,0 +1,98 @@
+"""Simple caching utilities for Jan Assistant Pro."""
+
+from __future__ import annotations
+
+import pickle
+import threading
+import time
+from hashlib import sha256
+from pathlib import Path
+from typing import Any
+
+from cachetools import LRUCache, TTLCache
+
+from .utils import thread_safe
+
+# ---------------------------------------------------------------------------
+# In-memory caches
+# ---------------------------------------------------------------------------
+
+# Default caches for general use. Size and ttl are conservative so they work in
+# most environments but can be overridden when needed.
+MEMORY_LRU_CACHE = LRUCache(maxsize=128)
+MEMORY_TTL_CACHE = TTLCache(maxsize=128, ttl=300)
+
+
+def clear_memory_caches() -> None:
+    """Clear both default in-memory caches."""
+    MEMORY_LRU_CACHE.clear()
+    MEMORY_TTL_CACHE.clear()
+
+
+# ---------------------------------------------------------------------------
+# Disk cache implementation
+# ---------------------------------------------------------------------------
+
+
+class DiskCache:
+    """Very small disk-based cache using pickle files with TTL metadata."""
+
+    def __init__(self, cache_dir: str, default_ttl: int = 3600) -> None:
+        self.cache_dir = Path(cache_dir)
+        self.default_ttl = default_ttl
+        self._lock = threading.RLock()
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+
+    def _path_for_key(self, key: str) -> Path:
+        """Return a safe path for ``key``."""
+        hashed = sha256(key.encode("utf-8")).hexdigest()
+        return self.cache_dir / f"{hashed}.pkl"
+
+    def set(self, key: str, value: Any, ttl: int | None = None) -> None:
+        """Store ``value`` under ``key`` for ``ttl`` seconds."""
+        expires_at = time.time() + (ttl or self.default_ttl)
+        path = self._path_for_key(key)
+        data = {"expires_at": expires_at, "value": value}
+        with thread_safe(self._lock), open(path, "wb") as f:
+            pickle.dump(data, f)
+
+    def get(self, key: str) -> Any | None:
+        """Retrieve ``key`` if present and not expired."""
+        path = self._path_for_key(key)
+        if not path.exists():
+            return None
+        with thread_safe(self._lock):
+            try:
+                with open(path, "rb") as f:
+                    data = pickle.load(f)
+            except Exception:
+                # Corrupt cache; remove it
+                path.unlink(missing_ok=True)
+                return None
+        if data.get("expires_at", 0) < time.time():
+            path.unlink(missing_ok=True)
+            return None
+        return data.get("value")
+
+    def delete(self, key: str) -> None:
+        """Remove ``key`` from the cache."""
+        path = self._path_for_key(key)
+        with thread_safe(self._lock):
+            if path.exists():
+                path.unlink()
+
+    def clear(self) -> None:
+        """Clear the entire disk cache."""
+        with thread_safe(self._lock):
+            for file in self.cache_dir.glob("*.pkl"):
+                file.unlink()
+
+
+__all__ = [
+    "LRUCache",
+    "TTLCache",
+    "MEMORY_LRU_CACHE",
+    "MEMORY_TTL_CACHE",
+    "clear_memory_caches",
+    "DiskCache",
+]

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,24 @@
+import time
+
+from src.core.cache import (
+    MEMORY_LRU_CACHE,
+    MEMORY_TTL_CACHE,
+    DiskCache,
+    clear_memory_caches,
+)
+
+
+def test_disk_cache_expiration(tmp_path):
+    cache = DiskCache(str(tmp_path), default_ttl=1)
+    cache.set("a", 123)
+    assert cache.get("a") == 123
+    time.sleep(1.1)
+    assert cache.get("a") is None
+
+
+def test_clear_memory_caches():
+    MEMORY_LRU_CACHE["x"] = 1
+    MEMORY_TTL_CACHE["y"] = 2
+    clear_memory_caches()
+    assert len(MEMORY_LRU_CACHE) == 0
+    assert len(MEMORY_TTL_CACHE) == 0


### PR DESCRIPTION
## Summary
- add `cachetools` as a dependency
- create `src/core/cache.py` with in-memory and disk caches
- use caching in `FileTools.read_file` and `SystemTools.get_system_info`
- provide basic cache tests

## Testing
- `pip install aiohttp==3.9.5 prometheus-client==0.22.0 python-dotenv==1.0.1`
- `pip install httpx==0.27.0`
- `pip install psutil==5.9.5`
- `pytest -q tests/test_cache.py`

------
https://chatgpt.com/codex/tasks/task_e_6856158dce448328ab6898f025fe995f