### PR TITLE
Add caching support with new tests

### DIFF
--- a/src/core/cache.py
+++ b/src/core/cache.py
@@ -1,0 +1,58 @@
+import json
+import os
+import time
+from collections import OrderedDict
+from typing import Any, Optional
+
+
+class LRUCache:
+    """Simple LRU cache with TTL support."""
+
+    def __init__(self, max_size: int = 128, ttl: float = 60.0) -> None:
+        self.max_size = max_size
+        self.ttl = ttl
+        self.store: "OrderedDict[str, tuple[Any, float]]" = OrderedDict()
+
+    def get(self, key: str) -> Optional[Any]:
+        if key in self.store:
+            value, ts = self.store[key]
+            if time.time() - ts < self.ttl:
+                self.store.move_to_end(key)
+                return value
+            del self.store[key]
+        return None
+
+    def set(self, key: str, value: Any) -> None:
+        if key in self.store:
+            self.store.move_to_end(key)
+        self.store[key] = (value, time.time())
+        if len(self.store) > self.max_size:
+            self.store.popitem(last=False)
+
+
+class DiskCache:
+    """Disk-based cache with TTL."""
+
+    def __init__(self, cache_dir: str, ttl: float = 60.0) -> None:
+        self.cache_dir = cache_dir
+        self.ttl = ttl
+        os.makedirs(cache_dir, exist_ok=True)
+
+    def _path(self, key: str) -> str:
+        return os.path.join(self.cache_dir, f"{hash(key)}.json")
+
+    def get(self, key: str) -> Optional[Any]:
+        path = self._path(key)
+        if os.path.exists(path):
+            if time.time() - os.path.getmtime(path) < self.ttl:
+                with open(path, "r", encoding="utf-8") as f:
+                    return json.load(f)
+            os.remove(path)
+        return None
+
+    def set(self, key: str, value: Any) -> None:
+        path = self._path(key)
+        tmp = f"{path}.tmp"
+        with open(tmp, "w", encoding="utf-8") as f:
+            json.dump(value, f)
+        os.replace(tmp, path)

--- a/tests/test_async_api_client.py
+++ b/tests/test_async_api_client.py
@@ -4,12 +4,23 @@ import asyncio
 import pytest
 import aiohttp
 
+from src.core.cache import DiskCache
+
 from src.core.async_api_client import AsyncAPIClient
 from src.core.exceptions import APIError
 
 
-def _create_client():
-    return AsyncAPIClient(base_url="http://test", api_key="key", model="model")
+def _create_client(tmp_path=None):
+    kwargs = {}
+    if tmp_path is not None:
+        kwargs = {
+            "cache_size": 2,
+            "cache_ttl": 1,
+            "disk_cache": DiskCache(str(tmp_path), ttl=1),
+        }
+    return AsyncAPIClient(
+        base_url="http://test", api_key="key", model="model", **kwargs
+    )
 
 
 @pytest.mark.asyncio
@@ -76,3 +87,24 @@ async def test_health_check_failure():
     with patch.object(client, "chat_completion", side_effect=APIError("fail")):
         result = await client.health_check()
     assert result is False
+
+
+@pytest.mark.asyncio
+async def test_chat_completion_cache(tmp_path):
+    client = _create_client(tmp_path)
+    messages = [{"role": "user", "content": "hi"}]
+    async with client:
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(
+            return_value={"choices": [{"message": {"content": "ok"}}]}
+        )
+        mock_resp.raise_for_status = Mock()
+        mock_cm = AsyncMock()
+        mock_cm.__aenter__.return_value = mock_resp
+        mock_cm.__aexit__.return_value = None
+        with patch.object(client.session, "post", return_value=mock_cm) as post:
+            r1 = await client.chat_completion(messages)
+            r2 = await client.chat_completion(messages)
+            post.assert_called_once()
+    assert r1 == r2

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,91 @@
+import json
+import time
+from unittest.mock import patch
+
+import pytest
+
+from src.core.api_client import APIClient
+from src.core.cache import DiskCache
+from src.core.unified_config import UnifiedConfig
+
+
+def test_lru_cache_eviction_and_ttl(tmp_path):
+    client = APIClient(
+        base_url="http://test",
+        api_key="k",
+        model="m",
+        cache_size=2,
+        cache_ttl=1,
+        disk_cache_dir=str(tmp_path),
+    )
+
+    messages1 = [{"role": "user", "content": "a"}]
+    messages2 = [{"role": "user", "content": "b"}]
+    messages3 = [{"role": "user", "content": "c"}]
+
+    with client:
+
+        class FakeResp:
+            def __init__(self, data):
+                self._data = data
+
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return self._data
+
+        fake_resp1 = FakeResp({"id": 1})
+        fake_resp2 = FakeResp({"id": 2})
+        fake_resp3 = FakeResp({"id": 3})
+
+        with patch.object(
+            client._async_client.session,
+            "post",
+            side_effect=[fake_resp1, fake_resp2, fake_resp3, fake_resp2],
+        ) as post:
+            r1 = client.chat_completion(messages1)
+            r2 = client.chat_completion(messages2)
+            assert post.call_count == 2
+            assert client.chat_completion(messages1) == r1
+            assert post.call_count == 2
+            client.chat_completion(messages3)
+            assert post.call_count == 3
+            assert client.chat_completion(messages2) == r2
+            assert post.call_count == 3
+            time.sleep(1.1)
+            client.chat_completion(messages2)
+            assert post.call_count == 4
+
+
+def test_disk_cache_read_write_expiry(tmp_path):
+    cache = DiskCache(str(tmp_path), ttl=0.5)
+    cache.set("k", {"v": 1})
+    assert cache.get("k") == {"v": 1}
+    time.sleep(0.6)
+    assert cache.get("k") is None
+
+
+def test_config_reload_after_ttl(tmp_path):
+    cfg_path = tmp_path / "c.json"
+    cfg_path.write_text(
+        json.dumps(
+            {
+                "api": {"base_url": "http://one", "api_key": "k", "model": "m"},
+                "memory": {"file": "mem.json"},
+            }
+        )
+    )
+
+    cfg = UnifiedConfig(config_path=str(cfg_path), reload_ttl=0.5)
+    assert cfg.get("api.base_url") == "http://one"
+    cfg_path.write_text(
+        json.dumps(
+            {
+                "api": {"base_url": "http://two", "api_key": "k", "model": "m"},
+                "memory": {"file": "mem.json"},
+            }
+        )
+    )
+    time.sleep(0.6)
+    assert cfg.get("api.base_url") == "http://two"


### PR DESCRIPTION
## Summary
- implement `LRUCache` and `DiskCache` utilities
- add optional caching to `AsyncAPIClient`, `APIClient`, and `UnifiedConfig`
- reload configuration when TTL expires
- create comprehensive `test_cache.py`
- update API client tests to exercise caching
- update async API client tests for caching behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685615bec15c83289473426a2e759697