### PR TITLE
Add API response caching

### DIFF
--- a/src/core/app_controller.py
+++ b/src/core/app_controller.py
@@ -24,7 +24,10 @@ class AppController:
             base_url=config.api_base_url,
             api_key=config.api_key,
             model=config.model_name,
-            timeout=int(config.get('api.timeout', 30))
+            timeout=int(config.get('api.timeout', 30)),
+            cache_enabled=bool(config.get('api.cache_enabled', False)),
+            cache_ttl=int(config.get('api.cache_ttl', 300)),
+            cache_size=int(config.get('api.cache_size', 128)),
         )
 
         self.memory_manager = MemoryManager(

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -65,6 +65,9 @@ class Config:
                 "api_key": "124578",
                 "model": "qwen3:30b-a3b",
                 "timeout": 30,
+                "cache_enabled": False,
+                "cache_ttl": 300,
+                "cache_size": 128,
             },
             "memory": {
                 "file": "data/memory.json",
@@ -173,6 +176,18 @@ class Config:
     @property
     def theme(self) -> str:
         return self.get("ui.theme", "dark")
+
+    @property
+    def cache_enabled(self) -> bool:
+        return bool(self.get("api.cache_enabled", False))
+
+    @property
+    def cache_ttl(self) -> int:
+        return int(self.get("api.cache_ttl", 300))
+
+    @property
+    def cache_size(self) -> int:
+        return int(self.get("api.cache_size", 128))
 
     def __str__(self):
         return f"Config(path={self.config_path})"

--- a/src/core/unified_config.py
+++ b/src/core/unified_config.py
@@ -63,6 +63,9 @@ class UnifiedConfig:
                 "api_key": "124578",
                 "model": "qwen3:30b-a3b",
                 "timeout": 30,
+                "cache_enabled": False,
+                "cache_ttl": 300,
+                "cache_size": 128,
             },
             "memory": {
                 "file": "data/memory.json",

--- a/tests/test_async_api_client.py
+++ b/tests/test_async_api_client.py
@@ -12,6 +12,17 @@ def _create_client():
     return AsyncAPIClient(base_url="http://test", api_key="key", model="model")
 
 
+def _create_cached_client():
+    return AsyncAPIClient(
+        base_url="http://test",
+        api_key="key",
+        model="model",
+        cache_enabled=True,
+        cache_ttl=60,
+        cache_size=10,
+    )
+
+
 @pytest.mark.asyncio
 async def test_chat_completion_success():
     client = _create_client()
@@ -76,3 +87,48 @@ async def test_health_check_failure():
     with patch.object(client, "chat_completion", side_effect=APIError("fail")):
         result = await client.health_check()
     assert result is False
+
+
+@pytest.mark.asyncio
+async def test_chat_completion_cached():
+    client = _create_cached_client()
+    messages = [{"role": "user", "content": "hi"}]
+    async with client:
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(return_value={"choices": [{"message": {"content": "hello"}}]})
+        mock_resp.raise_for_status = Mock()
+        mock_cm = AsyncMock()
+        mock_cm.__aenter__.return_value = mock_resp
+        mock_cm.__aexit__.return_value = None
+        with patch.object(client.session, "post", return_value=mock_cm) as post:
+            await client.chat_completion(messages)
+            await client.chat_completion(messages)
+            assert post.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_get_models_cached():
+    client = _create_cached_client()
+    async with client:
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(return_value={"data": [{"id": "1"}]})
+        mock_resp.raise_for_status = Mock()
+        mock_cm = AsyncMock()
+        mock_cm.__aenter__.return_value = mock_resp
+        mock_cm.__aexit__.return_value = None
+        with patch.object(client.session, "get", return_value=mock_cm) as get:
+            await client.get_models()
+            await client.get_models()
+            assert get.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_clear_api_cache():
+    client = _create_cached_client()
+    async with client:
+        client._cache["x"] = {"data": 1}
+        assert len(client._cache) == 1
+        client.clear_api_cache()
+        assert len(client._cache) == 0


### PR DESCRIPTION
## Summary
- implement TTL caching in both API client classes
- surface caching options in Config and AppController
- provide a clear_api_cache method
- test caching behaviour in async client

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685618d58d348328b7a6bb94c06a4faa