### PR TITLE
Add disk cache support for file and system tools

### DIFF
--- a/src/tools/file_tools.py
+++ b/src/tools/file_tools.py
@@ -345,7 +345,8 @@ class FileTools:
             cache_key = f"list:{Path(directory).resolve()}:{pattern}:{include_hidden}"
             if clear_cache and self.disk_cache:
                 self.disk_cache.delete(cache_key)
-            if use_cache and self.disk_cache and not clear_cache:
+            should_use_cache = use_cache and self.disk_cache and not clear_cache
+            if should_use_cache:
                 cached = self.disk_cache.get(cache_key)
                 if cached is not None:
                     return cached

--- a/src/tools/system_tools.py
+++ b/src/tools/system_tools.py
@@ -158,7 +158,7 @@ class SystemTools:
         if use_cache:
             if self.disk_cache:
                 cached = self.disk_cache.get(cache_key)
-        if cached is not None and use_cache and not clear_cache:
+        if cached is not None and not clear_cache:
             return cached
 
         try:

--- a/tests/test_system_tools.py
+++ b/tests/test_system_tools.py
@@ -1,5 +1,7 @@
 from unittest.mock import patch
 
+import platform
+import time
 from src.core.unified_config import UnifiedConfig
 from src.tools.system_tools import SystemTools
 
@@ -55,3 +57,28 @@ def test_check_network_connectivity_with_default_config(tmp_path):
         run_cmd.assert_called_once()
     assert result["success"] is True
     assert result["connected"] is True
+
+
+def test_get_system_info_disk_cache(monkeypatch, tmp_path):
+    cache_dir = tmp_path / "cache"
+    tools = SystemTools(disk_cache_dir=str(cache_dir), disk_cache_ttl=1)
+
+    monkeypatch.setattr(platform, "platform", lambda: "first")
+    res1 = tools.get_system_info()
+    assert res1["platform"] == "first"
+
+    monkeypatch.setattr(platform, "platform", lambda: "second")
+    res_cached = tools.get_system_info()
+    assert res_cached["platform"] == "first"
+
+    time.sleep(1.1)
+    res2 = tools.get_system_info()
+    assert res2["platform"] == "second"
+
+    monkeypatch.setattr(platform, "platform", lambda: "third")
+    res_bypass = tools.get_system_info(use_cache=False)
+    assert res_bypass["platform"] == "third"
+
+    monkeypatch.setattr(platform, "platform", lambda: "fourth")
+    res_clear = tools.get_system_info(clear_cache=True)
+    assert res_clear["platform"] == "fourth"


### PR DESCRIPTION
## Summary
- use `DiskCache` for `FileTools.list_files`
- use `DiskCache` for `SystemTools.get_system_info`
- support bypassing and clearing disk caches
- test disk cache logic for file and system tools

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68561b62b0ac83289b55c1dbd05ecd87