### PR TITLE
Add config TTL caching

### DIFF
--- a/config/config.example.json
+++ b/config/config.example.json
@@ -1,34 +1,31 @@
 {
-  "api": {
-    "base_url": "http://127.0.0.1:1337/v1",
-    "api_key": "your-api-key",
-    "model": "qwen3:30b-a3b",
-    "timeout": 30
-  },
-  "memory": {
-    "file": "data/memory.json",
-    "max_entries": 1000,
-    "auto_save": true
-  },
-  "ui": {
-    "theme": "dark",
-    "window_size": "800x600",
-    "font_family": "Consolas",
-    "font_size": 10
-  },
-  "tools": {
-    "file_operations": true,
-    "system_commands": true,
-    "memory_operations": true,
-    "web_search": false
-  },
-  "security": {
-    "allowed_commands": ["ls", "pwd", "cat", "echo", "ping"],
-    "blocked_commands": ["rm", "shutdown"],
-    "restricted_paths": ["/etc", "/sys", "/proc"],
-    "command_timeout": 30,
-    "max_command_output": "20KB",
-    "sandbox_dir": "sandbox",
-    "max_file_size": "10MB"
-  }
+    "api": {
+        "base_url": "http://127.0.0.1:1337/v1",
+        "api_key": "your-api-key",
+        "model": "qwen3:30b-a3b",
+        "timeout": 30,
+    },
+    "memory": {"file": "data/memory.json", "max_entries": 1000, "auto_save": true},
+    "ui": {
+        "theme": "dark",
+        "window_size": "800x600",
+        "font_family": "Consolas",
+        "font_size": 10,
+    },
+    "tools": {
+        "file_operations": true,
+        "system_commands": true,
+        "memory_operations": true,
+        "web_search": false,
+    },
+    "security": {
+        "allowed_commands": ["ls", "pwd", "cat", "echo", "ping"],
+        "blocked_commands": ["rm", "shutdown"],
+        "restricted_paths": ["/etc", "/sys", "/proc"],
+        "command_timeout": 30,
+        "max_command_output": "20KB",
+        "sandbox_dir": "sandbox",
+        "max_file_size": "10MB",
+    },
+    "cache": {"config": {"ttl": 300, "size": 4}},
 }

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -4,7 +4,10 @@ Configuration management for Jan Assistant Pro
 
 import json
 import os
+import time
 from typing import Any, Dict
+
+from cachetools import TTLCache
 
 from .logging_config import get_logger
 
@@ -18,7 +21,10 @@ class Config:
             f"{self.__class__.__module__}.{self.__class__.__name__}",
             {"config_path": self.config_path},
         )
+        self._cache: TTLCache | None = None
+        self._last_load: float = 0.0
         self.config_data = self._load_config()
+        self._init_cache()
 
     def _find_config_path(self) -> str:
         """Find the configuration file path"""
@@ -40,22 +46,34 @@ class Config:
 
     def _load_config(self) -> Dict[str, Any]:
         """Load configuration from file or create default"""
+        if self._cache is not None:
+            cached = self._cache.get(self.config_path)
+            if cached is not None:
+                self._last_load = cached["timestamp"]
+                return cached["data"]
+
         if os.path.exists(self.config_path):
             try:
                 with open(self.config_path, "r") as f:
-                    return json.load(f)
+                    data = json.load(f)
             except (json.JSONDecodeError, IOError) as e:
                 self.logger.warning(
                     "Could not load config file",
                     extra={"extra_fields": {"error": str(e), "path": self.config_path}},
                 )
-                return self._get_default_config()
+                data = self._get_default_config()
         else:
-            # Create default config
-            config = self._get_default_config()
+            data = self._get_default_config()
             self._ensure_config_dir()
-            self.save_config(config)
-            return config
+            self.save_config(data)
+
+        self._last_load = time.time()
+        if self._cache is not None:
+            self._cache[self.config_path] = {
+                "data": data,
+                "timestamp": self._last_load,
+            }
+        return data
 
     def _get_default_config(self) -> Dict[str, Any]:
         """Get default configuration"""
@@ -99,6 +117,7 @@ class Config:
                 "restricted_paths": ["/etc", "/sys", "/proc"],
                 "max_file_size": "10MB",
             },
+            "cache": {"config": {"ttl": 300, "size": 4}},
         }
 
     def _ensure_config_dir(self):
@@ -107,8 +126,23 @@ class Config:
         if not os.path.exists(config_dir):
             os.makedirs(config_dir, exist_ok=True)
 
+    def _init_cache(self) -> None:
+        cache_cfg = self.config_data.get("cache", {}).get("config", {})
+        size = int(cache_cfg.get("size", 4))
+        ttl = int(cache_cfg.get("ttl", 300))
+        self._cache = TTLCache(maxsize=size, ttl=ttl)
+        self._cache[self.config_path] = {
+            "data": self.config_data,
+            "timestamp": self._last_load,
+        }
+
+    def _check_reload(self) -> None:
+        if self._cache is not None and self._cache.get(self.config_path) is None:
+            self.reload()
+
     def get(self, key_path: str, default=None):
         """Get configuration value using dot notation (e.g., 'api.base_url')"""
+        self._check_reload()
         keys = key_path.split(".")
         value = self.config_data
 
@@ -122,6 +156,7 @@ class Config:
 
     def set(self, key_path: str, value: Any):
         """Set configuration value using dot notation"""
+        self._check_reload()
         keys = key_path.split(".")
         config = self.config_data
 
@@ -150,7 +185,10 @@ class Config:
 
     def reload(self):
         """Reload configuration from file"""
+        if self._cache is not None:
+            self._cache.pop(self.config_path, None)
         self.config_data = self._load_config()
+        self._init_cache()
 
     # Convenience properties for common config values
     @property
@@ -188,6 +226,20 @@ class Config:
     @property
     def cache_size(self) -> int:
         return int(self.get("api.cache_size", 128))
+
+    @property
+    def config_cache_ttl(self) -> int:
+        cache_cfg = self.get("cache.config.ttl", 300)
+        return int(cache_cfg)
+
+    @property
+    def config_cache_size(self) -> int:
+        cache_cfg = self.get("cache.config.size", 4)
+        return int(cache_cfg)
+
+    @property
+    def last_loaded(self) -> float:
+        return self._last_load
 
     def __str__(self):
         return f"Config(path={self.config_path})"

--- a/tests/test_config_cache_reload.py
+++ b/tests/test_config_cache_reload.py
@@ -1,0 +1,40 @@
+import os
+import sys
+import time
+
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src"))
+)
+
+from src.core.config import Config
+from src.core.unified_config import UnifiedConfig
+
+
+def _write_config(path, base_url):
+    path.write_text(
+        '{"api": {"base_url": "'
+        + base_url
+        + '", "api_key": "k", "model": "m"}, "memory": {"file": "mem"}, "cache": {"config": {"ttl": 1, "size": 1}}}'
+    )
+
+
+def test_config_reload_after_ttl(tmp_path):
+    cfg_file = tmp_path / "config.json"
+    _write_config(cfg_file, "http://a")
+    cfg = Config(config_path=str(cfg_file))
+    assert cfg.get("api.base_url") == "http://a"
+
+    _write_config(cfg_file, "http://b")
+    time.sleep(1.1)
+    assert cfg.get("api.base_url") == "http://b"
+
+
+def test_unified_config_reload_after_ttl(tmp_path):
+    cfg_file = tmp_path / "config.json"
+    _write_config(cfg_file, "http://a")
+    cfg = UnifiedConfig(config_path=str(cfg_file))
+    assert cfg.get("api.base_url") == "http://a"
+
+    _write_config(cfg_file, "http://c")
+    time.sleep(1.1)
+    assert cfg.get("api.base_url") == "http://c"


### PR DESCRIPTION
## Summary
- support caching of config data in Config and UnifiedConfig
- reload from disk automatically when TTL expires
- expose new `cache.config` section in example config
- test config reload logic

## Testing
- `ruff check src/core/config.py src/core/unified_config.py tests/test_config_cache_reload.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68561ba16fbc8328bda1c0fc3c502ca3