### PR TITLE
Add retry decorator with tests

### DIFF
--- a/src/core/retry.py
+++ b/src/core/retry.py
@@ -1,0 +1,64 @@
+"""Retry decorator utilities."""
+
+from __future__ import annotations
+
+import asyncio
+import functools
+import time
+from typing import Callable, Iterable, Type
+
+from .exceptions import RetryableError
+
+
+DEFAULT_EXCEPTIONS = (RetryableError,)
+
+
+def retry(
+    *,
+    max_attempts: int = 3,
+    initial_delay: float = 1.0,
+    backoff_factor: float = 2.0,
+    exceptions: Iterable[Type[Exception]] = DEFAULT_EXCEPTIONS,
+) -> Callable:
+    """Retry calling the wrapped function on specified exceptions."""
+
+    exc_tuple = tuple(exceptions)
+
+    def decorator(func: Callable) -> Callable:
+        if asyncio.iscoroutinefunction(func):
+
+            async def async_wrapper(*args, **kwargs):
+                delay = initial_delay
+                attempt = 0
+                while True:
+                    try:
+                        return await func(*args, **kwargs)
+                    except exc_tuple:
+                        attempt += 1
+                        if attempt >= max_attempts:
+                            raise
+                        await asyncio.sleep(delay)
+                        delay *= backoff_factor
+
+            return functools.wraps(func)(async_wrapper)
+
+        def wrapper(*args, **kwargs):
+            delay = initial_delay
+            attempt = 0
+            while True:
+                try:
+                    return func(*args, **kwargs)
+                except exc_tuple:
+                    attempt += 1
+                    if attempt >= max_attempts:
+                        raise
+                    time.sleep(delay)
+                    delay *= backoff_factor
+
+        return functools.wraps(func)(wrapper)
+
+    return decorator
+
+
+__all__ = ["retry"]
+

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -59,7 +59,7 @@ def test_retry_backoff_timing():
     def fake_sleep(dur):
         sleep_durations.append(dur)
 
-    with patch('time.sleep', side_effect=fake_sleep):
+    with patch('src.core.retry.time.sleep', side_effect=fake_sleep):
         result = fail_then_succeed(counter)
     assert result == 'done'
     assert sleep_durations == [0.1, 0.2]

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -1,0 +1,65 @@
+import asyncio
+import os
+import sys
+from unittest.mock import patch, AsyncMock
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src')))
+
+from src.core.retry import retry
+from src.core.exceptions import RetryableError
+
+
+class CustomError(RetryableError):
+    pass
+
+
+@retry(max_attempts=3, initial_delay=0, backoff_factor=1, exceptions=(CustomError,))
+async def flaky_async(counter):
+    counter['count'] += 1
+    if counter['count'] < 3:
+        raise CustomError('fail')
+    return 'ok'
+
+
+@retry(max_attempts=2, initial_delay=0, backoff_factor=1, exceptions=(CustomError,))
+def always_fail(counter):
+    counter['count'] += 1
+    raise CustomError('fail')
+
+
+@retry(max_attempts=3, initial_delay=0.1, backoff_factor=2, exceptions=(CustomError,))
+def fail_then_succeed(counter):
+    counter['count'] += 1
+    if counter['count'] < 3:
+        raise CustomError('fail')
+    return 'done'
+
+
+@pytest.mark.asyncio
+async def test_retry_success_after_retries_async():
+    counter = {'count': 0}
+    result = await flaky_async(counter)
+    assert result == 'ok'
+    assert counter['count'] == 3
+
+
+def test_retry_exhausts_after_max_attempts():
+    counter = {'count': 0}
+    with pytest.raises(CustomError):
+        always_fail(counter)
+    assert counter['count'] == 2
+
+
+def test_retry_backoff_timing():
+    counter = {'count': 0}
+    sleep_durations = []
+
+    def fake_sleep(dur):
+        sleep_durations.append(dur)
+
+    with patch('time.sleep', side_effect=fake_sleep):
+        result = fail_then_succeed(counter)
+    assert result == 'done'
+    assert sleep_durations == [0.1, 0.2]


### PR DESCRIPTION
## Summary
- create a generic `retry` decorator handling sync and async functions
- support configuration of attempts, delays, backoff and retryable exceptions
- add tests for retry behaviour including backoff timing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856201973108328aef703fd37132bea