### PR TITLE
Improve degraded mode handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ A **professional-grade**, local-first AI assistant with enterprise-ready archite
 - 🔒 **Privacy First**: Everything runs locally, your data stays yours
 - ⚙️ **Enterprise Configuration**: Validated JSON configuration with rich schemas
 - 📈 **Prometheus Metrics**: Built-in metrics endpoint for monitoring
+- ♻️ **Degraded Mode**: Cached tool output shown when the API is unreachable
 
 ## 📸 Screenshots
 
@@ -148,6 +149,13 @@ Set a value to `0` to disable a cache. TTL values are in seconds.
 
 To clear all caches, delete the contents of the `data/cache` directory and
 restart the application.
+
+### Degraded Mode
+
+If the connection to the language model fails, Jan Assistant Pro enters a
+degraded mode. The last successful tool output is returned so you can keep
+working offline. The incident is logged and normal responses resume once the
+API becomes available.
 
 ### Jan.ai Setup
 

--- a/tests/test_app_controller.py
+++ b/tests/test_app_controller.py
@@ -1,0 +1,40 @@
+import os
+import sys
+from unittest.mock import patch
+
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src"))
+)
+
+from src.core.app_controller import AppController
+from src.core.config import Config
+from src.core.api_client import APIError
+
+
+def _create_config(tmp_path):
+    cfg_path = tmp_path / "config.json"
+    cfg_path.write_text(
+        '{"api": {"base_url": "http://test", "api_key": "k", "model": "m"}, "memory": {"file": "mem"}}'
+    )
+    return Config(config_path=str(cfg_path))
+
+
+def test_chat_with_tools_api_error_no_cache(tmp_path):
+    cfg = _create_config(tmp_path)
+    controller = AppController(cfg)
+    with patch.object(
+        controller.api_client, "chat_completion", side_effect=APIError("boom")
+    ):
+        message = controller._chat_with_tools("hello")
+    assert "unable to reach" in message.lower()
+
+
+def test_chat_with_tools_api_error_with_cached_result(tmp_path):
+    cfg = _create_config(tmp_path)
+    controller = AppController(cfg)
+    controller.last_tool_result = "cached result"
+    with patch.object(
+        controller.api_client, "chat_completion", side_effect=APIError("down")
+    ):
+        message = controller._chat_with_tools("hello")
+    assert "cached result" in message


### PR DESCRIPTION
## Summary
- gracefully return cached tool output in AppController when the LLM API fails
- log API failures with LoggerMixin
- document degraded mode in README
- add tests covering degraded mode logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685623d80218832898c3271a14388655