### PR TITLE
Add in-memory error reporter with CLI

### DIFF
--- a/error_report_cli.py
+++ b/error_report_cli.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+"""Display aggregated recent errors."""
+import json
+
+from src.core.error_reporter import generate_report
+
+
+def main() -> None:
+    report = generate_report()
+    print(json.dumps(report, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/core/error_reporter.py
+++ b/src/core/error_reporter.py
@@ -1,0 +1,36 @@
+from collections import Counter, deque
+from typing import Any, Deque, Dict
+
+
+class ErrorReporter:
+    """Keep a rolling log of recent errors."""
+
+    def __init__(self, max_entries: int = 50) -> None:
+        self.max_entries = max_entries
+        self._errors: Deque[Dict[str, str]] = deque(maxlen=max_entries)
+
+    def record_error(self, exc: Exception) -> None:
+        """Record an exception."""
+        self._errors.append({"type": exc.__class__.__name__, "message": str(exc)})
+
+    def generate_report(self) -> Dict[str, Any]:
+        """Return aggregated error counts and recent messages."""
+        counts = Counter(err["type"] for err in self._errors)
+        return {
+            "total_errors": len(self._errors),
+            "counts": dict(counts),
+            "recent": list(self._errors),
+        }
+
+
+_default_reporter = ErrorReporter()
+
+
+def record_error(exc: Exception) -> None:
+    """Record an error using the global reporter."""
+    _default_reporter.record_error(exc)
+
+
+def generate_report() -> Dict[str, Any]:
+    """Generate a report from the global reporter."""
+    return _default_reporter.generate_report()

--- a/src/core/exceptions.py
+++ b/src/core/exceptions.py
@@ -5,6 +5,8 @@ Provides structured error handling throughout the application
 
 from typing import Any, Dict, Optional
 
+from .error_reporter import record_error
+
 
 class JanAssistantError(Exception):
     """Base exception for all Jan Assistant Pro errors"""
@@ -153,6 +155,7 @@ def handle_exception(exc: Exception) -> Dict[str, Any]:
     Returns:
         Standardized error dictionary
     """
+    record_error(exc)
     if isinstance(exc, JanAssistantError):
         return {
             'success': False,

--- a/tests/test_error_reporter.py
+++ b/tests/test_error_reporter.py
@@ -1,0 +1,56 @@
+import os
+import sys
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
+
+from src.core import exceptions as exc
+from src.core.error_reporter import ErrorReporter
+
+
+def test_error_reporter_aggregation():
+    reporter = ErrorReporter(max_entries=5)
+    try:
+        raise ValueError("bad")
+    except ValueError as e:
+        reporter.record_error(e)
+    try:
+        raise RuntimeError("boom")
+    except RuntimeError as e:
+        reporter.record_error(e)
+    try:
+        raise ValueError("again")
+    except ValueError as e:
+        reporter.record_error(e)
+
+    report = reporter.generate_report()
+
+    assert report["total_errors"] == 3
+    assert report["counts"]["ValueError"] == 2
+    assert report["counts"]["RuntimeError"] == 1
+    assert report["recent"][-1]["message"] == "again"
+
+
+def test_error_reporter_rolling_log():
+    reporter = ErrorReporter(max_entries=2)
+    reporter.record_error(Exception("1"))
+    reporter.record_error(Exception("2"))
+    reporter.record_error(Exception("3"))
+
+    report = reporter.generate_report()
+    assert report["total_errors"] == 2
+    messages = [e["message"] for e in report["recent"]]
+    assert messages == ["2", "3"]
+
+
+def test_handle_exception_records(monkeypatch):
+    captured = []
+
+    def fake_record(err):
+        captured.append(err)
+
+    with patch("src.core.exceptions.record_error", fake_record):
+        exc.handle_exception(ValueError("boom"))
+
+    assert len(captured) == 1
+    assert isinstance(captured[0], ValueError)


### PR DESCRIPTION
## Summary
- track recent errors in new `ErrorReporter`
- integrate reporter with `handle_exception`
- add CLI script `error_report_cli.py`
- test aggregation and recording behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685625dc189c8328add52c09fc6dfb2c