### PR TITLE
Use shared APIError class

### DIFF
--- a/src/core/api_client.py
+++ b/src/core/api_client.py
@@ -11,6 +11,7 @@ from .cache import TTLCache
 from .circuit_breaker import CircuitBreaker
 
 from src.core.metrics import api_calls, api_errors, api_latency
+from .exceptions import APIError
 
 import httpx
 
@@ -377,9 +378,3 @@ class APIClient:
             }
         except Exception:
             return {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
-
-
-class APIError(Exception):
-    """Custom exception for API-related errors"""
-
-    pass

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -4,7 +4,8 @@ import time
 import pytest
 
 
-from src.core.api_client import APIClient, APIError
+from src.core.api_client import APIClient
+from src.core.exceptions import APIError
 from src.core.circuit_breaker import CircuitBreaker
 
 

--- a/tests/test_app_controller.py
+++ b/tests/test_app_controller.py
@@ -8,7 +8,7 @@ sys.path.insert(
 
 from src.core.app_controller import AppController
 from src.core.config import Config
-from src.core.api_client import APIError
+from src.core.exceptions import APIError
 
 
 def _create_config(tmp_path):


### PR DESCRIPTION
## Summary
- import `APIError` from `src.core.exceptions` in `api_client`
- remove duplicate `APIError` class
- adjust tests to import from `exceptions`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685627f3d9148328878df03e485fcbe8