### PR TITLE
Handle optional deps in tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,6 +117,10 @@ python -m pytest tests/ --cov=src/
 python -m pytest tests/test_api_client.py
 ```
 
+Some tests rely on optional packages like `psutil` (system metrics) and
+`tkinter` (GUI widgets). If these modules are not installed, pytest will skip
+the corresponding tests automatically.
+
 ### Writing Tests
 
 - Place tests in the `tests/` directory

--- a/tests/test_gui_widgets.py
+++ b/tests/test_gui_widgets.py
@@ -1,7 +1,9 @@
 import os
 import sys
-import tkinter as tk
 import unittest
+import pytest
+
+tk = pytest.importorskip("tkinter")
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src')))
 

--- a/tests/test_gui_widgets.py
+++ b/tests/test_gui_widgets.py
@@ -3,7 +3,7 @@ import sys
 import unittest
 import pytest
 
-tk = pytest.importorskip("tkinter")
+tk = pytest.importorskip("tkinter", reason="required for GUI widget tests")
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src')))
 

--- a/tests/test_system_tools.py
+++ b/tests/test_system_tools.py
@@ -4,7 +4,7 @@ import platform
 import time
 import pytest
 
-pytest.importorskip("psutil")
+pytest.importorskip("psutil", reason="psutil is required for system metrics tests")
 
 from src.core.unified_config import UnifiedConfig
 from src.tools.system_tools import SystemTools

--- a/tests/test_system_tools.py
+++ b/tests/test_system_tools.py
@@ -2,6 +2,10 @@ from unittest.mock import patch
 
 import platform
 import time
+import pytest
+
+pytest.importorskip("psutil")
+
 from src.core.unified_config import UnifiedConfig
 from src.tools.system_tools import SystemTools
 


### PR DESCRIPTION
## Summary
- skip GUI widget tests when tkinter isn't available
- skip system tools tests if psutil isn't installed
- document optional test deps in CONTRIBUTING

## Testing
- `poetry run pytest tests/ -v` *(fails: ModuleNotFoundError: No module named 'cachetools', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68562b70a80c832888c6a899d2ab1375