### PR TITLE
Add coverage generation to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,5 +20,10 @@ jobs:
         run: pip install poetry
       - name: Install dependencies
         run: poetry install --with dev
-      - name: Run tests
-        run: poetry run pytest -q
+      - name: Run tests with coverage
+        run: poetry run pytest --cov=src --cov-report=xml -q
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage-report
+          path: coverage.xml

--- a/README.md
+++ b/README.md
@@ -330,11 +330,16 @@ coverage html  # Creates htmlcov/ directory
 
 **Test Coverage:**
 - 🧪 **Unit Tests**: Individual component testing
-- 🔗 **Integration Tests**: Cross-component interaction testing  
+- 🔗 **Integration Tests**: Cross-component interaction testing
 - 🎭 **Mock Testing**: External dependency isolation
 - 🏗️ **Architecture Tests**: Design pattern validation
 - 🚨 **Error Testing**: Exception handling verification
 - ⚡ **Performance Tests**: Speed and memory benchmarks
+
+#### Coverage Results
+
+CI runs tests with `pytest-cov` and saves a `coverage.xml` artifact. Download this
+file from the workflow run or connect Codecov for detailed coverage reports.
 
 ### Code Style
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ ruff = "^0.4.4"
 mypy = "^1.0"
 pre-commit = "^3.5"
 pytest-asyncio = "^0.23"
+pytest-cov = "^6.2"
 
 [build-system]
 requires = ["poetry-core>=1.9.0"]


### PR DESCRIPTION
## Summary
- run pytest with coverage in CI
- upload coverage.xml as an artifact
- record pytest-cov in dev dependencies
- document how to access coverage results

## Testing
- `pytest`
- `pytest --cov=src --cov-report=xml`

------
https://chatgpt.com/codex/tasks/task_e_685631ec8268832882e706c477913339