### PR TITLE
Add safety audit to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,14 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'poetry'
       - name: Install Poetry
         run: pip install poetry
       - name: Install dependencies
         run: poetry install --with dev
+      - name: Install safety
+        run: pip install safety
       - name: Run tests
         run: poetry run pytest -q
+      - name: Run security audit
+        run: poetry run safety check

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -185,6 +185,7 @@ After using a tool, I'll provide the result and you can respond naturally to the
 - Run with minimal user privileges
 - Firewall rules should only allow Jan.ai communication
 - Keep dependencies updated
+- Run `safety check` during CI to detect vulnerable packages
 - Review allowed commands and paths regularly
 
 ## Future Roadmap


### PR DESCRIPTION
## Summary
- run `safety check` in CI
- cache Poetry environment
- mention security audit in AGENTS doc

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cachetools')*

------
https://chatgpt.com/codex/tasks/task_e_685633d04380832880141073a0d256f1