### PR TITLE
Add benchmarks with pytest-benchmark

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,3 +27,10 @@ jobs:
         with:
           name: coverage-report
           path: coverage.xml
+      - name: Run benchmarks
+        run: poetry run pytest tests/test_performance.py --benchmark-only --benchmark-json=benchmark.json
+      - name: Upload benchmark results
+        uses: actions/upload-artifact@v3
+        with:
+          name: benchmark-results
+          path: benchmark.json

--- a/README.md
+++ b/README.md
@@ -321,8 +321,8 @@ python -m pytest tests/test_enhanced_features.py -v     # New features
 python -m pytest tests/test_memory_manager.py -v       # Memory system
 python -m pytest tests/test_file_tools.py -v          # File operations
 
-# Run performance tests
-python -m pytest tests/ -k "performance" -v
+# Run performance benchmarks
+python -m pytest tests/test_performance.py --benchmark-only -v
 
 # Generate coverage report
 coverage html  # Creates htmlcov/ directory

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ mypy = "^1.0"
 pre-commit = "^3.5"
 pytest-asyncio = "^0.23"
 pytest-cov = "^6.2"
+pytest-benchmark = "^4.0"
 
 [build-system]
 requires = ["poetry-core>=1.9.0"]

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -1,0 +1,28 @@
+import uuid
+
+from src.core.memory import MemoryManager
+from src.tools.file_tools import FileTools
+
+
+def test_memory_remember_recall_benchmark(tmp_path, benchmark):
+    mem_file = tmp_path / "memory.json"
+    manager = MemoryManager(str(mem_file), auto_save=False)
+
+    def run():
+        key = str(uuid.uuid4())
+        manager.remember(key, "value")
+        manager.recall(key)
+        manager.forget(key)
+
+    benchmark(run)
+
+
+def test_file_tools_write_read_benchmark(tmp_path, benchmark):
+    tools = FileTools()
+    file_path = tmp_path / "bench.txt"
+
+    def run():
+        tools.write_file(str(file_path), "hello", overwrite=True)
+        tools.read_file(str(file_path))
+
+    benchmark(run)


### PR DESCRIPTION
## Summary
- add pytest-benchmark as a dev dependency
- introduce `tests/test_performance.py` with basic benchmarks
- run benchmarks in CI and upload results
- document benchmark usage in README

## Testing
- `pytest tests/test_performance.py --benchmark-only -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685633dac4a0832883f6369765c44128