### PR TITLE
Add Python 3.11 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python


### PR DESCRIPTION
## Summary
- extend GitHub Actions matrix to test on Python 3.11

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68563581a0448328be413d21806609aa