### PR TITLE
Add release-please workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,19 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: google-github-actions/release-please-action@v4
+        with:
+          release-type: python
+          package-name: jan-assistant-pro
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ config/config.json
 # Data
 data/
 *.json
+!release-please-config.json
 !config/config.example.json
 
 # Logs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -384,13 +384,20 @@ We follow [Semantic Versioning](https://semver.org/):
 - **MINOR**: New features (backward compatible)
 - **PATCH**: Bug fixes (backward compatible)
 
-### Release Checklist
+### Automated Releases
 
-- [ ] Update version in `setup.py`
-- [ ] Update `CHANGELOG.md`
-- [ ] Create release notes
-- [ ] Tag release: `git tag v0.1.0`
-- [ ] Push tags: `git push --tags`
+Releases are managed by the `release-please` GitHub Action. Version numbers and
+changelogs are generated from commit messages using the Conventional Commits
+specification (`feat:`, `fix:` and so on). Whenever changes are merged into the
+`main` branch, the workflow creates or updates a release PR. Once merged,
+`release-please` tags the commit and publishes the changelog automatically.
+
+To ensure your changes appear correctly in the changelog, write commit messages
+using the Conventional Commits style. Example:
+
+```bash
+git commit -m "feat: add amazing new tool"
+```
 
 ## 🤝 Community
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,4 @@
+{
+  "release-type": "python",
+  "package-name": "jan-assistant-pro"
+}


### PR DESCRIPTION
## Summary
- add release-please workflow to automate releases
- configure release-please for the project
- document automated release process in CONTRIBUTING
- allow release-please config file in `.gitignore`

## Testing
- `pre-commit run --files .github/workflows/release.yml release-please-config.json CONTRIBUTING.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685637ad9f548328a6c505c54714c156