### PR TITLE
Add SQLite migration system

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,17 @@ Set a value to `0` to disable a cache. TTL values are in seconds.
 To clear all caches, delete the contents of the `data/cache` directory and
 restart the application.
 
+### Database Migrations
+
+The SQLite memory database is versioned with a lightweight migration system.
+Migrations are stored in `src/migrations/` and run automatically when the
+`EnhancedMemoryManager` starts. You can apply or rollback migrations manually:
+
+```bash
+python -m src.core.migration_manager data/memory.sqlite        # apply pending
+python -m src.core.migration_manager data/memory.sqlite --rollback 1
+```
+
 ### Degraded Mode
 
 If the connection to the language model fails, Jan Assistant Pro enters a

--- a/config/config.example.json
+++ b/config/config.example.json
@@ -5,7 +5,12 @@
         "model": "qwen3:30b-a3b",
         "timeout": 30,
     },
-    "memory": {"file": "data/memory.json", "max_entries": 1000, "auto_save": true},
+    "memory": {
+        "file": "data/memory.json",
+        "db": "data/memory.sqlite",
+        "max_entries": 1000,
+        "auto_save": true,
+    },
     "ui": {
         "theme": "dark",
         "window_size": "800x600",

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -397,6 +397,21 @@ Set any value to `0` to disable caching. TTL values are in seconds.
 
 Clear caches by deleting `data/cache/*` and restarting the app.
 
+### Database Migrations
+
+The SQLite memory database schema is versioned using a simple migration
+system located in `src/migrations/`. Each migration file exposes
+`upgrade(conn)` and `downgrade(conn)` functions. The current schema
+version is stored in the `schema_version` table.
+
+Migrations run automatically when `EnhancedMemoryManager` initializes, but
+you can apply or roll back migrations manually:
+
+```bash
+python -m src.core.migration_manager data/memory.sqlite        # apply
+python -m src.core.migration_manager data/memory.sqlite --rollback 1
+```
+
 ## Logging
 
 ### Setup Logging

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -17,7 +17,9 @@ from .logging_config import get_logger
 class Config:
     """Configuration manager for the application"""
 
-    def __init__(self, config_path: str = None, event_manager: EventManager | None = None):
+    def __init__(
+        self, config_path: str = None, event_manager: EventManager | None = None
+    ):
         self.config_path = config_path or self._find_config_path()
         self.event_manager = event_manager
         self.logger = get_logger(
@@ -93,6 +95,7 @@ class Config:
             },
             "memory": {
                 "file": "data/memory.json",
+                "db": "data/memory.sqlite",
                 "max_entries": 1000,
                 "auto_save": True,
             },
@@ -220,6 +223,10 @@ class Config:
     @property
     def memory_file(self) -> str:
         return self.get("memory.file", "data/memory.json")
+
+    @property
+    def memory_db_path(self) -> str:
+        return self.get("memory.db", "data/memory.sqlite")
 
     @property
     def window_size(self) -> str:

--- a/src/core/memory.py
+++ b/src/core/memory.py
@@ -396,25 +396,9 @@ class EnhancedMemoryManager:
         """Initialize SQLite database"""
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
 
-        with self._get_connection() as conn:
-            conn.execute(
-                """
-                CREATE TABLE IF NOT EXISTS memories (
-                    key TEXT PRIMARY KEY,
-                    value TEXT NOT NULL,
-                    category TEXT DEFAULT 'general',
-                    timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,
-                    access_count INTEGER DEFAULT 0,
-                    last_accessed DATETIME
-                )
-                """
-            )
-            conn.execute(
-                "CREATE INDEX IF NOT EXISTS idx_category ON memories(category)"
-            )
-            conn.execute(
-                "CREATE INDEX IF NOT EXISTS idx_timestamp ON memories(timestamp)"
-            )
+        from .migration_manager import apply_migrations
+
+        apply_migrations(str(self.db_path))
 
     @contextmanager
     def _get_connection(self):

--- a/src/core/migration_manager.py
+++ b/src/core/migration_manager.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import importlib.util
+import sqlite3
+from pathlib import Path
+from typing import Callable
+
+
+MIGRATIONS_DIR = Path(__file__).resolve().parents[1] / "migrations"
+
+
+def _load_migration(path: Path):
+    spec = importlib.util.spec_from_file_location(path.stem, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)  # type: ignore[attr-defined]
+    return module
+
+
+def _ensure_schema_table(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS schema_version("
+        "version INTEGER PRIMARY KEY,"
+        "applied_at TEXT)"
+    )
+
+
+def _get_current_version(conn: sqlite3.Connection) -> int:
+    row = conn.execute("SELECT MAX(version) FROM schema_version").fetchone()
+    return int(row[0]) if row and row[0] is not None else 0
+
+
+def apply_migrations(db_path: str) -> None:
+    """Apply all pending migrations to the database."""
+    db = Path(db_path)
+    db.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(db)
+    try:
+        _ensure_schema_table(conn)
+        current_version = _get_current_version(conn)
+        migration_files = [
+            p for p in MIGRATIONS_DIR.glob("*.py") if p.stem[0].isdigit()
+        ]
+        migration_files.sort()
+        for path in migration_files:
+            version = int(path.stem.split("_", 1)[0])
+            if version <= current_version:
+                continue
+            module = _load_migration(path)
+            upgrade: Callable[[sqlite3.Connection], None] = getattr(module, "upgrade")
+            with conn:
+                upgrade(conn)
+                conn.execute(
+                    "INSERT INTO schema_version(version, applied_at) VALUES (?, datetime('now'))",
+                    (version,),
+                )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def rollback(db_path: str, target_version: int) -> None:
+    """Rollback database to the specified version."""
+    conn = sqlite3.connect(db_path)
+    try:
+        _ensure_schema_table(conn)
+        current_version = _get_current_version(conn)
+        if target_version >= current_version:
+            return
+        migration_files = [
+            p for p in MIGRATIONS_DIR.glob("*.py") if p.stem[0].isdigit()
+        ]
+        migration_files.sort(reverse=True)
+        for path in migration_files:
+            version = int(path.stem.split("_", 1)[0])
+            if version > current_version:
+                continue
+            if version > target_version:
+                module = _load_migration(path)
+                downgrade: Callable[[sqlite3.Connection], None] = getattr(
+                    module, "downgrade"
+                )
+                with conn:
+                    downgrade(conn)
+                    conn.execute(
+                        "DELETE FROM schema_version WHERE version = ?", (version,)
+                    )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Manage database migrations")
+    parser.add_argument("db_path", help="Path to SQLite database")
+    parser.add_argument(
+        "--rollback", type=int, dest="rollback_to", help="Rollback to version"
+    )
+    args = parser.parse_args()
+
+    if args.rollback_to is not None:
+        rollback(args.db_path, args.rollback_to)
+    else:
+        apply_migrations(args.db_path)

--- a/src/migrations/0001_initial.py
+++ b/src/migrations/0001_initial.py
@@ -1,0 +1,22 @@
+import sqlite3
+
+
+def upgrade(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS memories (
+            key TEXT PRIMARY KEY,
+            value TEXT NOT NULL,
+            category TEXT DEFAULT 'general',
+            timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,
+            access_count INTEGER DEFAULT 0,
+            last_accessed DATETIME
+        )
+        """
+    )
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_category ON memories(category)")
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_timestamp ON memories(timestamp)")
+
+
+def downgrade(conn: sqlite3.Connection) -> None:
+    conn.execute("DROP TABLE IF EXISTS memories")

--- a/src/migrations/0002_add_notes_table.py
+++ b/src/migrations/0002_add_notes_table.py
@@ -1,0 +1,16 @@
+import sqlite3
+
+
+def upgrade(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS memory_notes (
+            key TEXT PRIMARY KEY,
+            note TEXT NOT NULL
+        )
+        """
+    )
+
+
+def downgrade(conn: sqlite3.Connection) -> None:
+    conn.execute("DROP TABLE IF EXISTS memory_notes")

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -1,0 +1,76 @@
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from src.core.migration_manager import apply_migrations, rollback
+from src.core.memory import EnhancedMemoryManager
+
+
+def _schema_version(db_path: Path) -> int:
+    conn = sqlite3.connect(db_path)
+    try:
+        row = conn.execute("SELECT MAX(version) FROM schema_version").fetchone()
+        return row[0] or 0
+    finally:
+        conn.close()
+
+
+LATEST_VERSION = 2
+
+
+def test_new_database_initialized(tmp_path):
+    db = tmp_path / "mem.sqlite"
+    apply_migrations(str(db))
+    assert _schema_version(db) == LATEST_VERSION
+
+
+def test_upgrade_preserves_data(tmp_path):
+    db = tmp_path / "upgrade.sqlite"
+    apply_migrations(str(db))
+    rollback(str(db), 1)
+
+    conn = sqlite3.connect(db)
+    conn.execute(
+        "INSERT INTO memories (key, value) VALUES (?, ?)",
+        ("foo", "bar"),
+    )
+    conn.commit()
+    conn.close()
+
+    apply_migrations(str(db))
+
+    manager = EnhancedMemoryManager(str(db))
+    recalled = manager.recall("foo")
+    assert recalled is not None and recalled["value"] == "bar"
+    assert _schema_version(db) == LATEST_VERSION
+
+
+def test_failed_migration_rolls_back(tmp_path, monkeypatch):
+    db = tmp_path / "fail.sqlite"
+    apply_migrations(str(db))
+    rollback(str(db), 1)
+
+    import types
+    from src.core import migration_manager as mm
+
+    orig = mm._load_migration
+
+    def patched(path: Path):
+        mod = orig(path)
+        if "0002_add_notes_table" in path.name:
+            mod.upgrade = lambda conn: (_ for _ in ()).throw(RuntimeError("boom"))
+        return mod
+
+    monkeypatch.setattr(mm, "_load_migration", patched)
+
+    with pytest.raises(RuntimeError):
+        apply_migrations(str(db))
+
+    assert _schema_version(db) == 1
+    conn = sqlite3.connect(db)
+    cur = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='memory_notes'"
+    )
+    assert cur.fetchone() is None
+    conn.close()


### PR DESCRIPTION
## Summary
- add new migration manager with CLI
- create migrations directory with initial schema
- track DB schema version in SQLite
- call migrations from `EnhancedMemoryManager`
- allow configuring SQLite DB path via config
- document migrations in docs and README
- test migration logic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6856ba0d495c8328893de9959bee549d