### PR TITLE
Add property-based tests with Hypothesis

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ pre-commit = "^3.5"
 pytest-asyncio = "^0.23"
 pytest-cov = "^6.2"
 pytest-benchmark = "^4.0"
+hypothesis = "^6.0"
 
 [build-system]
 requires = ["poetry-core>=1.9.0"]

--- a/tests/test_hypothesis_config.py
+++ b/tests/test_hypothesis_config.py
@@ -1,0 +1,35 @@
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from src.core.config_validator import ConfigValidator
+
+
+def valid_config_strategy(tmp_path):
+    return st.fixed_dictionaries(
+        {
+            "api": st.fixed_dictionaries(
+                {
+                    "base_url": st.sampled_from(
+                        ["http://example.com", "https://example.com"]
+                    ),
+                    "api_key": st.text(min_size=1, max_size=20),
+                    "model": st.text(min_size=1, max_size=20),
+                    "timeout": st.integers(min_value=1, max_value=300),
+                }
+            ),
+            "memory": st.fixed_dictionaries(
+                {"file": st.just(str(tmp_path / "mem.json"))}
+            ),
+        }
+    )
+
+
+@settings(max_examples=10, suppress_health_check=[HealthCheck.function_scoped_fixture])
+@given(st.data())
+def test_config_validation_generated(tmp_path, data):
+    validator = ConfigValidator()
+    cfg_strategy = valid_config_strategy(tmp_path)
+    config = data.draw(cfg_strategy)
+    validated = validator.validate_config_data(config)
+    assert validated["api"]["api_key"] == config["api"]["api_key"]
+    assert validated["memory"]["file"] == str(tmp_path / "mem.json")

--- a/tests/test_hypothesis_file_tools.py
+++ b/tests/test_hypothesis_file_tools.py
@@ -1,0 +1,43 @@
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from src.core.cache import clear_memory_caches
+from src.tools.file_tools import FileTools
+
+
+@settings(max_examples=10, suppress_health_check=[HealthCheck.function_scoped_fixture])
+@given(
+    file_name=st.text(
+        alphabet=st.characters(min_codepoint=97, max_codepoint=122),
+        min_size=1,
+        max_size=10,
+    ),
+    content=st.text(
+        alphabet=st.characters(min_codepoint=97, max_codepoint=122),
+        min_size=1,
+        max_size=50,
+    ),
+)
+def test_file_tools_operations(tmp_path, file_name, content):
+    clear_memory_caches()
+    tools = FileTools()
+    path = tmp_path / file_name
+
+    if path.exists():
+        path.unlink()
+
+    write = tools.write_file(str(path), content)
+    assert write["success"] is True
+
+    read = tools.read_file(str(path))
+    assert read["content"] == content
+
+    append_content = content[::-1]
+    tools.append_file(str(path), append_content)
+    clear_memory_caches()
+    read2 = tools.read_file(str(path))
+    assert read2["content"] == content + append_content
+
+    delete = tools.delete_file(str(path))
+    assert delete["success"] is True
+    assert not path.exists()

--- a/tests/test_hypothesis_memory.py
+++ b/tests/test_hypothesis_memory.py
@@ -1,0 +1,26 @@
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from src.core.memory import MemoryManager
+
+
+@settings(max_examples=10, suppress_health_check=[HealthCheck.function_scoped_fixture])
+@given(
+    st.dictionaries(
+        st.text(min_size=1, max_size=10),
+        st.text(min_size=1, max_size=20),
+        min_size=1,
+        max_size=10,
+    )
+)
+def test_memory_roundtrip(tmp_path, entries):
+    path = tmp_path / "memory.json"
+    with MemoryManager(str(path)) as manager:
+        for key, value in entries.items():
+            assert manager.remember(key, value)
+
+    with MemoryManager(str(path)) as manager:
+        for key, value in entries.items():
+            recalled = manager.recall(key)
+            assert recalled is not None
+            assert recalled["value"] == value

--- a/tests/test_tool_fuzzing.py
+++ b/tests/test_tool_fuzzing.py
@@ -1,0 +1,38 @@
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from src.tools.tool_registry import ToolRegistry
+from tests.test_enhanced_features import MockTool
+
+
+@settings(max_examples=10, suppress_health_check=[HealthCheck.function_scoped_fixture])
+@given(
+    include_input=st.booleans(),
+    input_text=st.text(min_size=0, max_size=20),
+    include_count=st.booleans(),
+    count_value=st.one_of(st.integers(min_value=0, max_value=5), st.text(), st.none()),
+)
+def test_tool_registry_fuzz(include_input, input_text, include_count, count_value):
+    registry = ToolRegistry()
+    registry.register_tool(MockTool)
+
+    params = {}
+    if include_input:
+        params["input"] = input_text
+    if include_count:
+        params["count"] = count_value
+
+    result = registry.execute_tool("mock_tool", **params)
+    assert "success" in result
+
+    valid = (
+        include_input
+        and input_text != "error"
+        and (not include_count or isinstance(count_value, int))
+    )
+    if valid:
+        expected_count = count_value if include_count else 1
+        assert result["success"] is True
+        assert result["result"] == input_text * expected_count
+    else:
+        assert result["success"] is False


### PR DESCRIPTION
## Summary
- add `hypothesis` to dev dependencies
- create property-based tests for memory manager
- create property-based tests for configuration validation
- create property-based tests for file tools
- add fuzzing tests for tool inputs

## Testing
- `pre-commit run --files pyproject.toml tests/test_hypothesis_memory.py tests/test_hypothesis_config.py tests/test_hypothesis_file_tools.py tests/test_tool_fuzzing.py` *(fails: mypy errors in repository)*
- `pytest tests/test_hypothesis_memory.py tests/test_hypothesis_config.py tests/test_hypothesis_file_tools.py tests/test_tool_fuzzing.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6856bc8b7c448328900b74c6ad184ad5