### PR TITLE
Add test fixtures and FactoryBoy factories

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ pytest-asyncio = "^0.23"
 pytest-cov = "^6.2"
 pytest-benchmark = "^4.0"
 hypothesis = "^6.0"
+factory-boy = "^3.3"
 
 [build-system]
 requires = ["poetry-core>=1.9.0"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,47 @@
+import os
+import sys
+import pytest
+
+# Ensure src package is importable
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
+
+from src.core.api_client import APIClient
+from src.core.async_api_client import AsyncAPIClient
+from .factories import ConfigFactory
+
+
+@pytest.fixture
+def api_client():
+    client = APIClient(base_url="http://test", api_key="key", model="model")
+    yield client
+    client.close()
+
+
+@pytest.fixture
+def async_api_client():
+    return AsyncAPIClient(base_url="http://test", api_key="key", model="model")
+
+
+@pytest.fixture
+def cached_async_api_client():
+    return AsyncAPIClient(
+        base_url="http://test",
+        api_key="key",
+        model="model",
+        cache_enabled=True,
+        cache_ttl=60,
+        cache_size=10,
+    )
+
+
+@pytest.fixture
+def temp_config(tmp_path):
+    return ConfigFactory(tmp_dir=tmp_path)
+
+
+@pytest.fixture
+def config_factory(tmp_path):
+    def _create(data=None):
+        return ConfigFactory(tmp_dir=tmp_path, data=data)
+
+    return _create

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -1,0 +1,37 @@
+import json
+import tempfile
+from pathlib import Path
+from datetime import datetime
+
+import factory
+
+from src.core.config import Config
+
+
+class ConfigFactory(factory.Factory):
+    """Factory for :class:`Config` objects backed by a temp file."""
+
+    class Meta:
+        model = Config
+
+    @classmethod
+    def _create(cls, model_class, tmp_dir=None, data=None, **kwargs):
+        tmp_dir = Path(tmp_dir or tempfile.mkdtemp())
+        config_path = tmp_dir / "config.json"
+        if data is None:
+            data = {
+                "api": {"base_url": "http://test", "api_key": "k", "model": "m"},
+                "memory": {"file": str(tmp_dir / "mem.json")},
+            }
+        config_path.write_text(json.dumps(data))
+        return model_class(config_path=str(config_path), **kwargs)
+
+
+class MemoryEntryFactory(factory.DictFactory):
+    """Factory for memory entry dictionaries."""
+
+    key = factory.Sequence(lambda n: f"key{n}")
+    value = factory.Faker("sentence")
+    category = "general"
+    timestamp = factory.LazyFunction(lambda: datetime.now().isoformat())
+    access_count = 0

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -9,46 +9,42 @@ from src.core.exceptions import APIError
 from src.core.circuit_breaker import CircuitBreaker
 
 
-def _create_client():
-    return APIClient(base_url="http://test", api_key="key", model="model")
-
-
-def test_chat_completion_success():
+def test_chat_completion_success(api_client):
     messages = [{"role": "user", "content": "hi"}]
     async_mock = AsyncMock(
         return_value={"choices": [{"message": {"content": "hello"}}]}
     )
-    with _create_client() as client:
-        with patch.object(client._async_client, "chat_completion", async_mock):
-            response = client.chat_completion(messages)
-            async_mock.assert_awaited_once_with(
-                messages, stream=False, temperature=0.7, max_tokens=None
-            )
-        assert response["choices"][0]["message"]["content"] == "hello"
-        assert client.extract_content(response) == "hello"
-    assert client._async_client.session is None
+    with patch.object(api_client._async_client, "chat_completion", async_mock):
+        response = api_client.chat_completion(messages)
+        async_mock.assert_awaited_once_with(
+            messages, stream=False, temperature=0.7, max_tokens=None
+        )
+    assert response["choices"][0]["message"]["content"] == "hello"
+    assert api_client.extract_content(response) == "hello"
+    api_client.close()
+    assert api_client._async_client.session is None
 
 
-def test_chat_completion_model_not_loaded():
+def test_chat_completion_model_not_loaded(api_client):
     messages = [{"role": "user", "content": "hi"}]
     async_mock = AsyncMock(side_effect=APIError("Model is not loaded"))
-    with _create_client() as client:
-        with patch.object(client._async_client, "chat_completion", async_mock):
-            with pytest.raises(APIError) as exc:
-                client.chat_completion(messages)
-        assert "Model is not loaded" in str(exc.value)
-    assert client._async_client.session is None
+    with patch.object(api_client._async_client, "chat_completion", async_mock):
+        with pytest.raises(APIError) as exc:
+            api_client.chat_completion(messages)
+    assert "Model is not loaded" in str(exc.value)
+    api_client.close()
+    assert api_client._async_client.session is None
 
 
-def test_chat_completion_connection_error():
+def test_chat_completion_connection_error(api_client):
     messages = [{"role": "user", "content": "hi"}]
     async_mock = AsyncMock(side_effect=APIError("Could not connect"))
-    with _create_client() as client:
-        with patch.object(client._async_client, "chat_completion", async_mock):
-            with pytest.raises(APIError) as exc:
-                client.chat_completion(messages)
-        assert "Could not connect" in str(exc.value)
-    assert client._async_client.session is None
+    with patch.object(api_client._async_client, "chat_completion", async_mock):
+        with pytest.raises(APIError) as exc:
+            api_client.chat_completion(messages)
+    assert "Could not connect" in str(exc.value)
+    api_client.close()
+    assert api_client._async_client.session is None
 
 
 def test_circuit_breaker_blocks_calls():

--- a/tests/test_app_controller.py
+++ b/tests/test_app_controller.py
@@ -7,20 +7,11 @@ sys.path.insert(
 )
 
 from src.core.app_controller import AppController
-from src.core.config import Config
 from src.core.exceptions import APIError
 
 
-def _create_config(tmp_path):
-    cfg_path = tmp_path / "config.json"
-    cfg_path.write_text(
-        '{"api": {"base_url": "http://test", "api_key": "k", "model": "m"}, "memory": {"file": "mem"}}'
-    )
-    return Config(config_path=str(cfg_path))
-
-
-def test_chat_with_tools_api_error_no_cache(tmp_path):
-    cfg = _create_config(tmp_path)
+def test_chat_with_tools_api_error_no_cache(temp_config):
+    cfg = temp_config
     controller = AppController(cfg)
     with patch.object(
         controller.api_client, "chat_completion", side_effect=APIError("boom")
@@ -29,8 +20,8 @@ def test_chat_with_tools_api_error_no_cache(tmp_path):
     assert "unable to reach" in message.lower()
 
 
-def test_chat_with_tools_api_error_with_cached_result(tmp_path):
-    cfg = _create_config(tmp_path)
+def test_chat_with_tools_api_error_with_cached_result(temp_config):
+    cfg = temp_config
     controller = AppController(cfg)
     controller.last_tool_result = "cached result"
     with patch.object(

--- a/tests/test_async_api_client.py
+++ b/tests/test_async_api_client.py
@@ -10,24 +10,9 @@ from src.core.exceptions import APIError
 from src.core.circuit_breaker import CircuitBreaker
 
 
-def _create_client():
-    return AsyncAPIClient(base_url="http://test", api_key="key", model="model")
-
-
-def _create_cached_client():
-    return AsyncAPIClient(
-        base_url="http://test",
-        api_key="key",
-        model="model",
-        cache_enabled=True,
-        cache_ttl=60,
-        cache_size=10,
-    )
-
-
 @pytest.mark.asyncio
-async def test_chat_completion_success():
-    client = _create_client()
+async def test_chat_completion_success(async_api_client):
+    client = async_api_client
     messages = [{"role": "user", "content": "hi"}]
     async with client:
         mock_resp = AsyncMock()
@@ -47,8 +32,8 @@ async def test_chat_completion_success():
 
 
 @pytest.mark.asyncio
-async def test_chat_completion_timeout():
-    client = _create_client()
+async def test_chat_completion_timeout(async_api_client):
+    client = async_api_client
     messages = [{"role": "user", "content": "hi"}]
     async with client:
         with patch.object(client.session, "post", side_effect=asyncio.TimeoutError):
@@ -57,8 +42,8 @@ async def test_chat_completion_timeout():
 
 
 @pytest.mark.asyncio
-async def test_chat_completion_client_error():
-    client = _create_client()
+async def test_chat_completion_client_error(async_api_client):
+    client = async_api_client
     messages = [{"role": "user", "content": "hi"}]
     async with client:
         with patch.object(client.session, "post", side_effect=aiohttp.ClientError):
@@ -67,8 +52,8 @@ async def test_chat_completion_client_error():
 
 
 @pytest.mark.asyncio
-async def test_get_models_success():
-    client = _create_client()
+async def test_get_models_success(async_api_client):
+    client = async_api_client
     async with client:
         mock_resp = AsyncMock()
         mock_resp.status = 200
@@ -84,16 +69,16 @@ async def test_get_models_success():
 
 
 @pytest.mark.asyncio
-async def test_health_check_failure():
-    client = _create_client()
+async def test_health_check_failure(async_api_client):
+    client = async_api_client
     with patch.object(client, "chat_completion", side_effect=APIError("fail")):
         result = await client.health_check()
     assert result is False
 
 
 @pytest.mark.asyncio
-async def test_chat_completion_cached():
-    client = _create_cached_client()
+async def test_chat_completion_cached(cached_async_api_client):
+    client = cached_async_api_client
     messages = [{"role": "user", "content": "hi"}]
     async with client:
         mock_resp = AsyncMock()
@@ -112,8 +97,8 @@ async def test_chat_completion_cached():
 
 
 @pytest.mark.asyncio
-async def test_get_models_cached():
-    client = _create_cached_client()
+async def test_get_models_cached(cached_async_api_client):
+    client = cached_async_api_client
     async with client:
         mock_resp = AsyncMock()
         mock_resp.status = 200
@@ -129,8 +114,8 @@ async def test_get_models_cached():
 
 
 @pytest.mark.asyncio
-async def test_clear_api_cache():
-    client = _create_cached_client()
+async def test_clear_api_cache(cached_async_api_client):
+    client = cached_async_api_client
     async with client:
         client._cache["x"] = {"data": 1}
         assert len(client._cache) == 1

--- a/tests/test_config_cache_reload.py
+++ b/tests/test_config_cache_reload.py
@@ -1,40 +1,42 @@
 import os
 import sys
 import time
+import json
+from pathlib import Path
 
-sys.path.insert(
-    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src"))
-)
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
 
-from src.core.config import Config
 from src.core.unified_config import UnifiedConfig
 
 
-def _write_config(path, base_url):
-    path.write_text(
-        '{"api": {"base_url": "'
-        + base_url
-        + '", "api_key": "k", "model": "m"}, "memory": {"file": "mem"}, "cache": {"config": {"ttl": 1, "size": 1}}}'
-    )
-
-
-def test_config_reload_after_ttl(tmp_path):
-    cfg_file = tmp_path / "config.json"
-    _write_config(cfg_file, "http://a")
-    cfg = Config(config_path=str(cfg_file))
+def test_config_reload_after_ttl(config_factory):
+    data = {
+        "api": {"base_url": "http://a", "api_key": "k", "model": "m"},
+        "memory": {"file": "mem"},
+        "cache": {"config": {"ttl": 1, "size": 1}},
+    }
+    cfg = config_factory(data=data)
+    cfg_file = Path(cfg.config_path)
     assert cfg.get("api.base_url") == "http://a"
 
-    _write_config(cfg_file, "http://b")
+    data["api"]["base_url"] = "http://b"
+    cfg_file.write_text(json.dumps(data))
     time.sleep(1.1)
     assert cfg.get("api.base_url") == "http://b"
 
 
-def test_unified_config_reload_after_ttl(tmp_path):
-    cfg_file = tmp_path / "config.json"
-    _write_config(cfg_file, "http://a")
-    cfg = UnifiedConfig(config_path=str(cfg_file))
-    assert cfg.get("api.base_url") == "http://a"
+def test_unified_config_reload_after_ttl(config_factory):
+    data = {
+        "api": {"base_url": "http://a", "api_key": "k", "model": "m"},
+        "memory": {"file": "mem"},
+        "cache": {"config": {"ttl": 1, "size": 1}},
+    }
+    cfg = config_factory(data=data)
+    cfg_file = Path(cfg.config_path)
+    uni_cfg = UnifiedConfig(config_path=str(cfg_file))
+    assert uni_cfg.get("api.base_url") == "http://a"
 
-    _write_config(cfg_file, "http://c")
+    data["api"]["base_url"] = "http://c"
+    cfg_file.write_text(json.dumps(data))
     time.sleep(1.1)
-    assert cfg.get("api.base_url") == "http://c"
+    assert uni_cfg.get("api.base_url") == "http://c"


### PR DESCRIPTION
## Summary
- add `factory-boy` dev dependency
- create `tests/conftest.py` with reusable fixtures
- add `tests/factories.py` for creating `Config` and memory data
- refactor tests to use fixtures and factories

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856c47fbbd08328872bf53942f740e4