### PR TITLE
Configure pytest asyncio options

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,6 +117,10 @@ python -m pytest tests/ --cov=src/
 python -m pytest tests/test_api_client.py
 ```
 
+Asynchronous tests use `pytest-asyncio`. The `pyproject.toml` config defines an
+`asyncio` marker and sets `asyncio_mode = "auto"` so the event loop policy is
+handled automatically.
+
 Some tests rely on optional packages like `psutil` (system metrics) and
 `tkinter` (GUI widgets). If these modules are not installed, pytest will skip
 the corresponding tests automatically.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,3 +57,5 @@ disallow_incomplete_defs = true
 minversion = "7.0"
 addopts = "-ra"
 testpaths = ["tests"]
+markers = ["asyncio"]
+asyncio_mode = "auto"


### PR DESCRIPTION
## Summary
- configure pytest-asyncio markers in `pyproject.toml`
- document running async tests in the contributing guide

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856cbb5bc588328a02d1fd893e94816