### PR TITLE
Add mock config fixtures

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import json
 import pytest
 
 # Ensure src package is importable
@@ -7,6 +8,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..",
 
 from src.core.api_client import APIClient
 from src.core.async_api_client import AsyncAPIClient
+from src.core.unified_config import UnifiedConfig
 from .factories import ConfigFactory
 
 
@@ -45,3 +47,46 @@ def config_factory(tmp_path):
         return ConfigFactory(tmp_dir=tmp_path, data=data)
 
     return _create
+
+
+def _build_config_data(tmp_path, invalid=False):
+    data = {
+        "api": {
+            "base_url": "http://test",
+            "api_key": "k",
+            "model": "m",
+            "timeout": 30,
+        },
+        "memory": {"file": str(tmp_path / "mem.json")},
+    }
+    if invalid:
+        data["api"]["timeout"] = "bad"
+    return data
+
+
+@pytest.fixture(params=["default", "invalid"])
+def mock_config(tmp_path, request):
+    """Return Config object for different scenarios."""
+    data = _build_config_data(tmp_path, invalid=request.param == "invalid")
+    return ConfigFactory(tmp_dir=tmp_path, data=data)
+
+
+@pytest.fixture(params=["default", "invalid"])
+def mock_unified_config(tmp_path, request):
+    """Return UnifiedConfig object for different scenarios."""
+    data = _build_config_data(tmp_path, invalid=request.param == "invalid")
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps(data))
+    return UnifiedConfig(config_path=str(config_path))
+
+
+@pytest.fixture
+def env_timeout(monkeypatch):
+    """Environment setting that overrides API timeout."""
+    monkeypatch.setenv("JAN_ASSISTANT_API_TIMEOUT", "45")
+
+
+@pytest.fixture
+def default_config_data(tmp_path):
+    """Return default configuration data dictionary."""
+    return _build_config_data(tmp_path)

--- a/tests/test_app_controller.py
+++ b/tests/test_app_controller.py
@@ -10,8 +10,12 @@ from src.core.app_controller import AppController
 from src.core.exceptions import APIError
 
 
-def test_chat_with_tools_api_error_no_cache(temp_config):
-    cfg = temp_config
+import pytest
+
+
+@pytest.mark.parametrize("mock_config", ["default"], indirect=True)
+def test_chat_with_tools_api_error_no_cache(mock_config):
+    cfg = mock_config
     controller = AppController(cfg)
     with patch.object(
         controller.api_client, "chat_completion", side_effect=APIError("boom")
@@ -20,8 +24,9 @@ def test_chat_with_tools_api_error_no_cache(temp_config):
     assert "unable to reach" in message.lower()
 
 
-def test_chat_with_tools_api_error_with_cached_result(temp_config):
-    cfg = temp_config
+@pytest.mark.parametrize("mock_config", ["default"], indirect=True)
+def test_chat_with_tools_api_error_with_cached_result(mock_config):
+    cfg = mock_config
     controller = AppController(cfg)
     controller.last_tool_result = "cached result"
     with patch.object(

--- a/tests/test_enhanced_config.py
+++ b/tests/test_enhanced_config.py
@@ -1,29 +1,25 @@
 import os
 import sys
+import json
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
 
 from src.core.unified_config import UnifiedConfig
+import pytest
 
 
-def test_env_override_int(tmp_path, monkeypatch):
-    config_file = tmp_path / "config.json"
-    config_file.write_text(
-        '{"api": {"base_url": "http://a", "api_key": "k", "model": "m", "timeout": 30}, "memory": {"file": "mem"}}'
-    )
-
-    monkeypatch.setenv("JAN_ASSISTANT_API_TIMEOUT", "45")
-    cfg = UnifiedConfig(config_path=str(config_file))
+@pytest.mark.parametrize("mock_unified_config", ["default"], indirect=True)
+def test_env_override_int(env_timeout, mock_unified_config):
+    cfg = mock_unified_config
     assert cfg.get("api.timeout") == 45
 
 
-def test_env_file_loading(tmp_path):
+def test_env_file_loading(default_config_data, tmp_path):
     config_file = tmp_path / "config.json"
-    config_file.write_text(
-        '{"api": {"base_url": "http://default", "api_key": "k", "model": "m"}, "memory": {"file": "mem"}}'
-    )
+    config_file.write_text(json.dumps(default_config_data))
     env_file = tmp_path / ".env"
     env_file.write_text("JAN_ASSISTANT_API_BASE_URL=http://envfile")
 
     cfg = UnifiedConfig(config_path=str(config_file), env_file=str(env_file))
     assert cfg.get("api.base_url") == "http://envfile"
+

--- a/tests/test_system_tools.py
+++ b/tests/test_system_tools.py
@@ -51,8 +51,9 @@ def test_check_network_connectivity_failure_result_error():
     assert "not allowed" in result["error"]
 
 
-def test_check_network_connectivity_with_default_config(tmp_path):
-    cfg = UnifiedConfig(config_path=str(tmp_path / "config.json"))
+@pytest.mark.parametrize("mock_unified_config", ["default"], indirect=True)
+def test_check_network_connectivity_with_default_config(mock_unified_config):
+    cfg = mock_unified_config
     tools = SystemTools(allowed_commands=cfg.get("security.allowed_commands"))
     assert "ping" in tools.allowed_commands
     mock_result = {'success': True, 'return_code': 0, 'stdout': 'ok', 'stderr': ''}


### PR DESCRIPTION
## Summary
- add helper fixtures to conftest for unified config scenarios
- parametrize app controller and system tools tests on these fixtures
- update enhanced config tests to use env fixture

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856cd784e748328ae8b497bf498a7d7