### PR TITLE
Add Sphinx documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ __pycache__/
 *.so
 .Python
 build/
+docs/build/
 develop-eggs/
 dist/
 downloads/
@@ -51,3 +52,4 @@ Thumbs.db
 # Temporary files
 *.tmp
 *.temp
+.hypothesis/

--- a/README.md
+++ b/README.md
@@ -432,6 +432,7 @@ We welcome contributions! Please see our [Contributing Guide](CONTRIBUTING.md) f
 ### Getting Help
 
 - 📖 Check our [Documentation](docs/)
+- 💡 Build API docs locally with `make html` in the `docs` directory
 - 🐛 Open an [Issue](https://github.com/CreativeNewEra/jan-assistant-pro/issues)
 - 💬 Start a [Discussion](https://github.com/CreativeNewEra/jan-assistant-pro/discussions)
 - 💝 Join our [Discord](https://discord.gg/your-discord-link)

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -676,6 +676,7 @@ setup_logging(log_level="DEBUG", enable_console=True)
 - [REFACTORING_SUMMARY.md](REFACTORING_SUMMARY.md) - Architecture changes overview
 - [HIGH_IMPACT_IMPROVEMENTS_SUMMARY.md](HIGH_IMPACT_IMPROVEMENTS_SUMMARY.md) - Detailed improvement guide
 - [API Documentation](api_docs/) - Auto-generated API documentation
+  (run `make html` in the `docs/` directory to build)
 - [Examples](../examples/) - Example implementations and usage patterns
 
 For questions or support, please open an issue on GitHub or join our community discussions.

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/source/api/generated/src.core.circuit_breaker.rst
+++ b/docs/source/api/generated/src.core.circuit_breaker.rst
@@ -1,0 +1,12 @@
+src.core.circuit\_breaker
+=========================
+
+.. automodule:: src.core.circuit_breaker
+
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      CircuitBreaker
+   

--- a/docs/source/api/generated/src.core.config_validator.rst
+++ b/docs/source/api/generated/src.core.config_validator.rst
@@ -1,0 +1,22 @@
+src.core.config\_validator
+==========================
+
+.. automodule:: src.core.config_validator
+
+   
+   .. rubric:: Functions
+
+   .. autosummary::
+   
+      create_jan_assistant_schema
+      validate_file_path
+      validate_url
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      ConfigSchema
+      ConfigValidator
+      ValidationRule
+   

--- a/docs/source/api/generated/src.core.error_reporter.rst
+++ b/docs/source/api/generated/src.core.error_reporter.rst
@@ -1,0 +1,19 @@
+src.core.error\_reporter
+========================
+
+.. automodule:: src.core.error_reporter
+
+   
+   .. rubric:: Functions
+
+   .. autosummary::
+   
+      generate_report
+      record_error
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      ErrorReporter
+   

--- a/docs/source/api/generated/src.core.event_manager.rst
+++ b/docs/source/api/generated/src.core.event_manager.rst
@@ -1,0 +1,12 @@
+src.core.event\_manager
+=======================
+
+.. automodule:: src.core.event_manager
+
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      EventManager
+   

--- a/docs/source/api/generated/src.core.exceptions.rst
+++ b/docs/source/api/generated/src.core.exceptions.rst
@@ -1,0 +1,29 @@
+src.core.exceptions
+===================
+
+.. automodule:: src.core.exceptions
+
+   
+   .. rubric:: Functions
+
+   .. autosummary::
+   
+      create_error_response
+      handle_exception
+   
+   .. rubric:: Exceptions
+
+   .. autosummary::
+   
+      APIError
+      ConfigurationError
+      FileOperationError
+      JanAssistantError
+      MemoryError
+      NetworkError
+      ResourceError
+      RetryableError
+      SecurityError
+      ToolError
+      ValidationError
+   

--- a/docs/source/api/generated/src.core.logging_config.rst
+++ b/docs/source/api/generated/src.core.logging_config.rst
@@ -1,0 +1,25 @@
+src.core.logging\_config
+========================
+
+.. automodule:: src.core.logging_config
+
+   
+   .. rubric:: Functions
+
+   .. autosummary::
+   
+      configure_third_party_loggers
+      create_audit_logger
+      get_logger
+      log_function_call
+      log_performance
+      setup_logging
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      ContextFilter
+      JSONFormatter
+      LoggerMixin
+   

--- a/docs/source/api/generated/src.core.memory.rst
+++ b/docs/source/api/generated/src.core.memory.rst
@@ -1,0 +1,13 @@
+src.core.memory
+===============
+
+.. automodule:: src.core.memory
+
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      EnhancedMemoryManager
+      MemoryManager
+   

--- a/docs/source/api/generated/src.core.migration_manager.rst
+++ b/docs/source/api/generated/src.core.migration_manager.rst
@@ -1,0 +1,13 @@
+src.core.migration\_manager
+===========================
+
+.. automodule:: src.core.migration_manager
+
+   
+   .. rubric:: Functions
+
+   .. autosummary::
+   
+      apply_migrations
+      rollback
+   

--- a/docs/source/api/generated/src.core.retry.rst
+++ b/docs/source/api/generated/src.core.retry.rst
@@ -1,0 +1,12 @@
+src.core.retry
+==============
+
+.. automodule:: src.core.retry
+
+   
+   .. rubric:: Functions
+
+   .. autosummary::
+   
+      retry
+   

--- a/docs/source/api/generated/src.core.rst
+++ b/docs/source/api/generated/src.core.rst
@@ -1,0 +1,30 @@
+src.core
+========
+
+.. automodule:: src.core
+
+   
+.. rubric:: Modules
+
+.. autosummary::
+   :toctree:
+   :recursive:
+
+   api_client
+   app_controller
+   async_api_client
+   cache
+   circuit_breaker
+   config
+   config_validator
+   enhanced_config
+   error_reporter
+   event_manager
+   exceptions
+   logging_config
+   memory
+   metrics
+   migration_manager
+   retry
+   unified_config
+   utils

--- a/docs/source/api/generated/src.core.utils.rst
+++ b/docs/source/api/generated/src.core.utils.rst
@@ -1,0 +1,12 @@
+src.core.utils
+==============
+
+.. automodule:: src.core.utils
+
+   
+   .. rubric:: Functions
+
+   .. autosummary::
+   
+      thread_safe
+   

--- a/docs/source/api/generated/src.gui.enhanced_widgets.rst
+++ b/docs/source/api/generated/src.gui.enhanced_widgets.rst
@@ -1,0 +1,14 @@
+src.gui.enhanced\_widgets
+=========================
+
+.. automodule:: src.gui.enhanced_widgets
+
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      ChatInput
+      EnhancedChatDisplay
+      StatusBar
+   

--- a/docs/source/api/generated/src.gui.rst
+++ b/docs/source/api/generated/src.gui.rst
@@ -1,0 +1,14 @@
+src.gui
+=======
+
+.. automodule:: src.gui
+
+   
+.. rubric:: Modules
+
+.. autosummary::
+   :toctree:
+   :recursive:
+
+   enhanced_widgets
+   main_window

--- a/docs/source/api/generated/src.migrations.rst
+++ b/docs/source/api/generated/src.migrations.rst
@@ -1,0 +1,14 @@
+src.migrations
+==============
+
+.. automodule:: src.migrations
+
+   
+.. rubric:: Modules
+
+.. autosummary::
+   :toctree:
+   :recursive:
+
+   0001_initial
+   0002_add_notes_table

--- a/docs/source/api/generated/src.plugins.plugin_loader.rst
+++ b/docs/source/api/generated/src.plugins.plugin_loader.rst
@@ -1,0 +1,12 @@
+src.plugins.plugin\_loader
+==========================
+
+.. automodule:: src.plugins.plugin_loader
+
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      PluginLoader
+   

--- a/docs/source/api/generated/src.plugins.rst
+++ b/docs/source/api/generated/src.plugins.rst
@@ -1,0 +1,13 @@
+src.plugins
+===========
+
+.. automodule:: src.plugins
+
+   
+.. rubric:: Modules
+
+.. autosummary::
+   :toctree:
+   :recursive:
+
+   plugin_loader

--- a/docs/source/api/generated/src.rst
+++ b/docs/source/api/generated/src.rst
@@ -1,0 +1,17 @@
+﻿src
+===
+
+.. automodule:: src
+
+   
+.. rubric:: Modules
+
+.. autosummary::
+   :toctree:
+   :recursive:
+
+   core
+   gui
+   migrations
+   plugins
+   tools

--- a/docs/source/api/generated/src.tools.base_tool.rst
+++ b/docs/source/api/generated/src.tools.base_tool.rst
@@ -1,0 +1,14 @@
+src.tools.base\_tool
+====================
+
+.. automodule:: src.tools.base_tool
+
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      BaseTool
+      ToolInfo
+      ToolParameter
+   

--- a/docs/source/api/generated/src.tools.rst
+++ b/docs/source/api/generated/src.tools.rst
@@ -1,0 +1,18 @@
+src.tools
+=========
+
+.. automodule:: src.tools
+
+   
+.. rubric:: Modules
+
+.. autosummary::
+   :toctree:
+   :recursive:
+
+   base_tool
+   file_tools
+   secure_command_executor
+   system_tools
+   tool_factory
+   tool_registry

--- a/docs/source/api/generated/src.tools.secure_command_executor.rst
+++ b/docs/source/api/generated/src.tools.secure_command_executor.rst
@@ -1,0 +1,12 @@
+src.tools.secure\_command\_executor
+===================================
+
+.. automodule:: src.tools.secure_command_executor
+
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      SecureCommandExecutor
+   

--- a/docs/source/api/generated/src.tools.tool_factory.rst
+++ b/docs/source/api/generated/src.tools.tool_factory.rst
@@ -1,0 +1,12 @@
+src.tools.tool\_factory
+=======================
+
+.. automodule:: src.tools.tool_factory
+
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      ToolFactory
+   

--- a/docs/source/api/generated/src.tools.tool_registry.rst
+++ b/docs/source/api/generated/src.tools.tool_registry.rst
@@ -1,0 +1,26 @@
+src.tools.tool\_registry
+========================
+
+.. automodule:: src.tools.tool_registry
+
+   
+   .. rubric:: Functions
+
+   .. autosummary::
+   
+      execute_tool
+      get_registry
+      register_tool
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      ToolRegistry
+   
+   .. rubric:: Exceptions
+
+   .. autosummary::
+   
+      ToolRegistryError
+   

--- a/docs/source/api/modules.rst
+++ b/docs/source/api/modules.rst
@@ -1,0 +1,8 @@
+API Reference
+=============
+
+.. autosummary::
+   :toctree: generated
+   :recursive:
+
+   src

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,48 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+project = 'Jan Assistant Pro'
+copyright = '2025, Your Name'
+author = 'Your Name'
+
+import os
+import sys
+sys.path.insert(0, os.path.abspath("../.."))
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.autosummary",
+    "sphinx.ext.viewcode",
+    "sphinx.ext.doctest",
+    "sphinx.ext.napoleon",
+    "sphinx.ext.autodoc.typehints",
+    "myst_parser",
+    "sphinxcontrib.mermaid",
+]
+
+autosummary_generate = True
+autodoc_default_options = {
+    "members": True,
+    "show-inheritance": True,
+}
+autodoc_typehints = "description"
+mermaid_output_format = "svg"
+
+templates_path = ['_templates']
+exclude_patterns = []
+
+
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = 'sphinx_rtd_theme'
+html_static_path = ['_static']

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -23,7 +23,7 @@ extensions = [
     "sphinx.ext.viewcode",
     "sphinx.ext.doctest",
     "sphinx.ext.napoleon",
-    "sphinx.ext.autodoc.typehints",
+    "sphinx_autodoc_typehints",
     "myst_parser",
     "sphinxcontrib.mermaid",
 ]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -37,7 +37,7 @@ autodoc_typehints = "description"
 mermaid_output_format = "svg"
 
 templates_path = ['_templates']
-exclude_patterns = []
+exclude_patterns = ['_build', 'generated']
 
 
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,0 +1,17 @@
+.. Jan Assistant Pro documentation master file, created by
+   sphinx-quickstart on Sat Jun 21 15:38:16 2025.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+
+Jan Assistant Pro Documentation
+===============================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   ../index.md
+   ../DEVELOPER_GUIDE.md
+   api/modules
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,13 @@ pytest-benchmark = "^4.0"
 hypothesis = "^6.0"
 factory-boy = "^3.3"
 
+[tool.poetry.group.docs.dependencies]
+sphinx = "^8.2"
+myst-parser = "^4.0"
+sphinx-autodoc-typehints = "^3.2"
+sphinxcontrib-mermaid = "^1.0"
+sphinx-rtd-theme = "^3.0"
+
 [build-system]
 requires = ["poetry-core>=1.9.0"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
## Summary
- add Sphinx configuration with autodoc, napoleon, and Mermaid support
- generate API stub files and update docs index
- document `make html` in README and developer guide
- ignore docs build output and Hypothesis cache

## Testing
- `pytest -q`
- `make html`

------
https://chatgpt.com/codex/tasks/task_e_6856d16cc7bc8328bdee89cd56a72eb1