### PR TITLE
Fix AsyncAPIClient cleanup

### DIFF
--- a/src/core/async_api_client.py
+++ b/src/core/async_api_client.py
@@ -56,6 +56,8 @@ class AsyncAPIClient:
         try:
             if self.session and not self.session.closed:
                 await self.session.close()
+        except Exception as e:
+            logging.error("Exception occurred while closing the session: %s", e, exc_info=True)
         finally:
             self.session = None  # Always cleanup reference
 

--- a/src/core/async_api_client.py
+++ b/src/core/async_api_client.py
@@ -53,9 +53,11 @@ class AsyncAPIClient:
         return self
 
     async def __aexit__(self, exc_type, exc, tb) -> None:
-        if self.session and not self.session.closed:
-            await self.session.close()
-        self.session = None
+        try:
+            if self.session and not self.session.closed:
+                await self.session.close()
+        finally:
+            self.session = None  # Always cleanup reference
 
     async def _ensure_session(self) -> aiohttp.ClientSession:
         if self.session is None or self.session.closed:


### PR DESCRIPTION
## Summary
- ensure async session is always cleaned up when exiting AsyncAPIClient context

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856edc3def083289bd2f832dddf5f23