### PR TITLE
Implement input validation decorator

### DIFF
--- a/src/core/utils.py
+++ b/src/core/utils.py
@@ -1,6 +1,7 @@
 import threading
 from contextlib import contextmanager
-from typing import Iterator
+from functools import wraps
+from typing import Any, Dict, Iterator
 
 
 @contextmanager
@@ -11,3 +12,26 @@ def thread_safe(lock: threading.Lock) -> Iterator[None]:
         yield
     finally:
         lock.release()
+
+
+def validate_input(rules: Dict[str, Any]):
+    """Validate keyword arguments against provided rules."""
+
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            for param, rule in rules.items():
+                if param in kwargs:
+                    value = kwargs[param]
+                    if "max_length" in rule and len(str(value)) > rule["max_length"]:
+                        raise ValueError(f"{param} exceeds max length")
+                    if "pattern" in rule and not rule["pattern"].match(str(value)):
+                        raise ValueError(f"{param} has invalid format")
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+__all__ = ["thread_safe", "validate_input"]

--- a/src/tools/system_tools.py
+++ b/src/tools/system_tools.py
@@ -4,11 +4,13 @@ System command tools for Jan Assistant Pro
 
 import os
 import platform
+import re
 from typing import Any, Dict, List
 
 from src.core.cache import DiskCache
 from src.core.logging_config import get_logger
 from src.core.metrics import record_tool
+from src.core.utils import validate_input
 from src.tools.secure_command_executor import SecureCommandExecutor
 
 # ---------------------------------------------------------------------------
@@ -88,6 +90,12 @@ class SystemTools:
 
         return command.strip()
 
+    @validate_input({
+        "command": {
+            "pattern": re.compile(r"^[a-zA-Z0-9\s\-.]+$"),
+            "max_length": 100,
+        }
+    })
     @record_tool("run_command")
     def run_command(
         self,

--- a/tests/test_input_validation.py
+++ b/tests/test_input_validation.py
@@ -1,0 +1,37 @@
+import re
+import pytest
+
+from src.core.utils import validate_input
+from src.tools.system_tools import SystemTools
+
+
+def test_validate_input_success():
+    @validate_input({"name": {"pattern": re.compile(r"^[a-z]+$"), "max_length": 5}})
+    def greet(name):
+        return name.upper()
+
+    assert greet(name="hello"[:5]) == "HELLO"
+
+
+def test_validate_input_length_error():
+    @validate_input({"text": {"max_length": 3}})
+    def echo(text):
+        return text
+
+    with pytest.raises(ValueError):
+        echo(text="abcd")
+
+
+def test_validate_input_pattern_error():
+    @validate_input({"value": {"pattern": re.compile(r"^[0-9]+$")}})
+    def num(value):
+        return int(value)
+
+    with pytest.raises(ValueError):
+        num(value="abc")
+
+
+def test_run_command_validation():
+    tools = SystemTools()
+    with pytest.raises(ValueError):
+        tools.run_command(command="rm -rf /tmp")


### PR DESCRIPTION
## Summary
- add `validate_input` decorator to core utils
- enforce validation on `SystemTools.run_command`
- test the new decorator and usage

## Testing
- `pytest tests/test_input_validation.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6856f79ecd54832896ce0a05a1c97b7f