### PR TITLE
Implement SecureConfig with keyring support

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,9 +75,12 @@ and enjoy inline autocomplete suggestions while typing.
 
 3. **Configure your API settings**:
    ```bash
-   cp config/config.example.json config/config.json
-   # Edit config.json with your API details
-   ```
+ cp config/config.example.json config/config.json
+ # Edit config.json with your API details
+ ```
+  You can also set the API key via the `JAN_API_KEY` environment variable. When
+  using `SecureConfig`, the key is saved to your system keyring after the first
+  prompt.
 
 4. **Run the application**:
    ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ packages = [{ include = "src" }]
 python = "^3.8"
 requests = ">=2.31.0"
 python-dotenv = ">=1.0.0"
+keyring = ">=24.0"
 psutil = { version = ">=5.8.0", optional = true }
 orjson = { version = ">=3.8.0", optional = true }
 httpx = { version = ">=0.25.0", optional = true }

--- a/src/core/__init__.py
+++ b/src/core/__init__.py
@@ -1,0 +1,11 @@
+from .config import Config
+from .enhanced_config import EnhancedConfig
+from .unified_config import UnifiedConfig
+from .secure_config import SecureConfig
+
+__all__ = [
+    "Config",
+    "EnhancedConfig",
+    "UnifiedConfig",
+    "SecureConfig",
+]

--- a/src/core/secure_config.py
+++ b/src/core/secure_config.py
@@ -34,7 +34,7 @@ class SecureConfig(Config):
 
         key = self._prompt_for_key()
         try:
-            keyring.set_password("jan-assistant", "api-key", key)
+            keyring.set_password(self.SERVICE_NAME, self.USERNAME, key)
         except KeyringError:
             pass
         return key

--- a/src/core/secure_config.py
+++ b/src/core/secure_config.py
@@ -28,13 +28,13 @@ class SecureConfig(Config):
             key = keyring.get_password("jan-assistant", "api-key")
             if key:
                 return key
-        except Exception:
+        except KeyringError:
             # Fall back to prompt if keyring fails
             key = None
 
         key = self._prompt_for_key()
         try:
             keyring.set_password("jan-assistant", "api-key", key)
-        except Exception:
+        except KeyringError:
             pass
         return key

--- a/src/core/secure_config.py
+++ b/src/core/secure_config.py
@@ -1,0 +1,40 @@
+"""Secure configuration using environment variables and keyring."""
+
+from __future__ import annotations
+
+import os
+from getpass import getpass
+
+import keyring
+
+from .config import Config
+
+
+class SecureConfig(Config):
+    """Configuration that retrieves the API key securely."""
+
+    def _prompt_for_key(self) -> str:
+        """Prompt the user for the API key."""
+        return getpass("Enter Jan API key: ")
+
+    @property
+    def api_key(self) -> str:  # type: ignore[override]
+        """Return the API key from env, keyring or user prompt."""
+        key = os.environ.get("JAN_API_KEY")
+        if key:
+            return key
+
+        try:
+            key = keyring.get_password("jan-assistant", "api-key")
+            if key:
+                return key
+        except Exception:
+            # Fall back to prompt if keyring fails
+            key = None
+
+        key = self._prompt_for_key()
+        try:
+            keyring.set_password("jan-assistant", "api-key", key)
+        except Exception:
+            pass
+        return key

--- a/tests/test_secure_config.py
+++ b/tests/test_secure_config.py
@@ -1,0 +1,37 @@
+import os
+import sys
+from unittest.mock import patch
+
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src"))
+)
+
+from src.core.secure_config import SecureConfig
+
+
+def test_api_key_from_env(monkeypatch):
+    monkeypatch.setenv("JAN_API_KEY", "envvalue")
+    cfg = SecureConfig()
+    assert cfg.api_key == "envvalue"
+
+
+def test_api_key_from_keyring(monkeypatch):
+    monkeypatch.delenv("JAN_API_KEY", raising=False)
+    with patch("keyring.get_password", return_value="ring") as get_pw:
+        cfg = SecureConfig()
+        assert cfg.api_key == "ring"
+        get_pw.assert_called_once_with("jan-assistant", "api-key")
+
+
+def test_api_key_prompt_and_store(monkeypatch):
+    monkeypatch.delenv("JAN_API_KEY", raising=False)
+    with patch("keyring.get_password", return_value=None):
+        with patch("keyring.set_password") as set_pw:
+
+            class TestConfig(SecureConfig):
+                def _prompt_for_key(self) -> str:  # type: ignore[override]
+                    return "prompt"
+
+            cfg = TestConfig()
+            assert cfg.api_key == "prompt"
+            set_pw.assert_called_once_with("jan-assistant", "api-key", "prompt")


### PR DESCRIPTION
## Summary
- add SecureConfig that loads API key from environment or keyring
- expose SecureConfig in `core.__init__`
- document JAN_API_KEY usage in README
- add dependency on `keyring`
- test SecureConfig behaviour

## Testing
- `pytest tests/test_secure_config.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6856f996400c832889003218a0d8b1e6