### PR TITLE
Add DegradedModeHandler for offline mode

### DIFF
--- a/src/core/degraded_mode.py
+++ b/src/core/degraded_mode.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from typing import Dict
+
+from .cache import LRUCache
+from .logging_config import get_logger
+
+"""Handler for offline or degraded mode operations."""
+
+
+class DegradedModeHandler:
+    """Provide responses when the application is offline."""
+
+    def __init__(self) -> None:
+        self.offline_responses: Dict[str, str] = {
+            "greeting": "Hello! I'm currently offline but can help with cached responses.",
+            "help": "Available offline commands: ...",
+        }
+        self.last_successful_responses: LRUCache[str, str] = LRUCache(maxsize=100)
+        self.logger = get_logger(f"{__name__}.DegradedModeHandler")
+
+    def cache_response(self, prompt: str, response: str) -> None:
+        """Store a successful response for offline use."""
+        self.last_successful_responses[prompt] = response
+        self.logger.debug("Cached successful response", prompt=prompt, cached=response)
+
+    def _classify_intent(self, message: str) -> str:
+        """Return a simple intent label based on the message."""
+        lowered = message.lower()
+        if "help" in lowered:
+            return "help"
+        if any(word in lowered for word in ("hello", "hi", "hey")):
+            return "greeting"
+        return "unknown"
+
+    def handle_offline_request(self, message: str) -> str:
+        """Return an offline response based on cached data or intent."""
+        if cached := self.last_successful_responses.get(message):
+            return f"\U0001f4f5 Offline Mode - Last response:\n{cached}"
+
+        return self.offline_responses.get(
+            self._classify_intent(message),
+            "\U0001f4f5 I'm currently offline. Please check your connection.",
+        )
+
+
+__all__ = ["DegradedModeHandler"]

--- a/tests/test_degraded_mode.py
+++ b/tests/test_degraded_mode.py
@@ -1,0 +1,20 @@
+from src.core.degraded_mode import DegradedModeHandler
+
+
+def test_offline_cached_response():
+    handler = DegradedModeHandler()
+    handler.cache_response("hi", "cached reply")
+    result = handler.handle_offline_request("hi")
+    assert "cached reply" in result
+
+
+def test_offline_help_response():
+    handler = DegradedModeHandler()
+    result = handler.handle_offline_request("help me")
+    assert "Available offline commands" in result
+
+
+def test_offline_default_message():
+    handler = DegradedModeHandler()
+    result = handler.handle_offline_request("unknown query")
+    assert "offline" in result.lower()


### PR DESCRIPTION
## Summary
- add `DegradedModeHandler` for cached responses in offline mode
- unit test for the degraded mode handler

## Testing
- `pytest tests/test_degraded_mode.py -q`
- `pytest -q` *(fails: missing optional deps and secure config test fails)*

------
https://chatgpt.com/codex/tasks/task_e_6856fd8890448328a850715896f9f963