### PR TITLE
Implement dataclass-based AppConfig loader

### DIFF
--- a/src/core/__init__.py
+++ b/src/core/__init__.py
@@ -1,15 +1,17 @@
+from .app_config import AppConfig
 from .config import Config
 from .enhanced_config import EnhancedConfig
-from .unified_config import UnifiedConfig
-from .secure_config import SecureConfig
-from .request_context import RequestContext
 from .health_checker import HealthChecker
+from .request_context import RequestContext
+from .secure_config import SecureConfig
+from .unified_config import UnifiedConfig
 
 __all__ = [
     "Config",
     "EnhancedConfig",
     "UnifiedConfig",
     "SecureConfig",
+    "AppConfig",
     "RequestContext",
     "HealthChecker",
 ]

--- a/src/core/app_config.py
+++ b/src/core/app_config.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import asdict, dataclass, field
+from typing import Any, Dict, Optional
+
+ENV_PREFIX = "JAN_ASSISTANT_"
+CONFIG_ENV_VAR = "JAN_ASSISTANT_CONFIG_FILE"
+
+SAFE_INFO_COMMANDS = ["ls", "pwd", "date", "whoami", "echo"]
+SAFE_READ_COMMANDS = ["cat", "head", "tail", "grep"]  # Still dangerous!
+
+
+@dataclass
+class APIConfig:
+    base_url: str = "http://127.0.0.1:1337/v1"
+    api_key: str = "124578"
+    model: str = "qwen3:30b-a3b"
+    timeout: int = 30
+
+
+@dataclass
+class SecurityConfig:
+    allowed_commands: list[str] = field(
+        default_factory=lambda: SAFE_INFO_COMMANDS + SAFE_READ_COMMANDS
+    )
+    restricted_paths: list[str] = field(
+        default_factory=lambda: ["/etc", "/sys", "/proc"]
+    )
+    max_file_size: str = "10MB"
+
+
+@dataclass
+class UIConfig:
+    theme: str = "dark"
+    window_size: str = "800x600"
+    font_family: str = "Consolas"
+    font_size: int = 10
+
+
+@dataclass
+class AppConfig:
+    api: APIConfig = field(default_factory=APIConfig)
+    security: SecurityConfig = field(default_factory=SecurityConfig)
+    ui: UIConfig = field(default_factory=UIConfig)
+
+    @classmethod
+    def load(cls) -> "AppConfig":
+        # 1. Load defaults
+        config = cls._defaults()
+
+        # 2. Merge with file
+        if file_config := cls._load_file():
+            config = cls._merge(config, file_config)
+
+        # 3. Override with env vars
+        config = cls._apply_env_overrides(config)
+
+        # 4. Validate
+        cls._validate(config)
+
+        return config
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _defaults() -> "AppConfig":
+        return AppConfig()
+
+    @staticmethod
+    def _load_file() -> Optional[Dict[str, Any]]:
+        path = os.environ.get(CONFIG_ENV_VAR)
+        if path and os.path.exists(path):
+            try:
+                with open(path, "r", encoding="utf-8") as f:
+                    return json.load(f)
+            except Exception:
+                return None
+
+        default_path = os.path.join(os.getcwd(), "config", "config.json")
+        if os.path.exists(default_path):
+            try:
+                with open(default_path, "r", encoding="utf-8") as f:
+                    return json.load(f)
+            except Exception:
+                return None
+        return None
+
+    @staticmethod
+    def _merge(base: "AppConfig", override: Dict[str, Any]) -> "AppConfig":
+        data = asdict(base)
+        AppConfig._deep_update(data, override)
+        return AppConfig._from_dict(data)
+
+    @staticmethod
+    def _deep_update(dest: Dict[str, Any], src: Dict[str, Any]) -> None:
+        for key, value in src.items():
+            if (
+                key in dest
+                and isinstance(dest[key], dict)
+                and isinstance(value, dict)
+            ):
+                AppConfig._deep_update(dest[key], value)
+            else:
+                dest[key] = value
+
+    @staticmethod
+    def _from_dict(data: Dict[str, Any]) -> "AppConfig":
+        return AppConfig(
+            api=APIConfig(**data.get("api", {})),
+            security=SecurityConfig(**data.get("security", {})),
+            ui=UIConfig(**data.get("ui", {})),
+        )
+
+    @staticmethod
+    def _apply_env_overrides(config: "AppConfig") -> "AppConfig":
+        data = asdict(config)
+        fields = [
+            "api.base_url",
+            "api.api_key",
+            "api.model",
+            "api.timeout",
+            "security.allowed_commands",
+            "security.restricted_paths",
+            "security.max_file_size",
+            "ui.theme",
+            "ui.window_size",
+            "ui.font_family",
+            "ui.font_size",
+        ]
+        for path in fields:
+            env_key = ENV_PREFIX + path.replace(".", "_").upper()
+            if env_key in os.environ:
+                value = AppConfig._convert_env(os.environ[env_key])
+                AppConfig._set_nested_value(data, path, value)
+        return AppConfig._from_dict(data)
+
+    @staticmethod
+    def _convert_env(value: str) -> Any:
+        lower = value.lower()
+        if lower in ("true", "false"):
+            return lower == "true"
+        if value.isdigit() or (value.startswith("-") and value[1:].isdigit()):
+            return int(value)
+        try:
+            return float(value)
+        except ValueError:
+            pass
+        if value.startswith("[") or value.startswith("{"):
+            try:
+                return json.loads(value)
+            except json.JSONDecodeError:
+                pass
+        return value
+
+    @staticmethod
+    def _set_nested_value(data: Dict[str, Any], path: str, value: Any) -> None:
+        keys = path.split(".")
+        d = data
+        for key in keys[:-1]:
+            if key not in d or not isinstance(d[key], dict):
+                d[key] = {}
+            d = d[key]
+        d[keys[-1]] = value
+
+    @staticmethod
+    def _validate(config: "AppConfig") -> None:
+        if not config.api.base_url:
+            raise ValueError("api.base_url is required")
+        if not config.api.api_key:
+            raise ValueError("api.api_key is required")
+        if not config.api.model:
+            raise ValueError("api.model is required")
+        if config.api.timeout <= 0:
+            raise ValueError("api.timeout must be positive")
+        if config.ui.theme not in ("dark", "light"):
+            raise ValueError("ui.theme must be 'dark' or 'light'")
+        if config.ui.font_size <= 0:
+            raise ValueError("ui.font_size must be positive")
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+

--- a/tests/test_app_config.py
+++ b/tests/test_app_config.py
@@ -1,0 +1,27 @@
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
+
+from src.core.app_config import AppConfig
+
+
+def test_app_config_load_env_override(monkeypatch, tmp_path):
+    cfg_file = tmp_path / "config.json"
+    cfg_file.write_text(
+        json.dumps({"api": {"base_url": "http://file", "api_key": "k", "model": "m"}, "ui": {"theme": "light"}})
+    )
+    monkeypatch.setenv("JAN_ASSISTANT_CONFIG_FILE", str(cfg_file))
+    monkeypatch.setenv("JAN_ASSISTANT_API_BASE_URL", "http://env")
+    config = AppConfig.load()
+    assert config.api.base_url == "http://env"
+    assert config.ui.theme == "light"
+    assert config.api.api_key == "k"
+
+
+def test_app_config_defaults(monkeypatch):
+    monkeypatch.delenv("JAN_ASSISTANT_CONFIG_FILE", raising=False)
+    config = AppConfig.load()
+    assert config.api.base_url == "http://127.0.0.1:1337/v1"
+    assert config.api.api_key == "124578"


### PR DESCRIPTION
## Summary
- implement `AppConfig` dataclass with defaults, file loading, env overrides and validation
- expose `AppConfig` in `src/core/__init__.py`
- add tests for new configuration loader

## Testing
- `ruff check tests/test_app_config.py src/core/app_config.py src/core/__init__.py`
- `pytest tests/test_app_config.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6857064ee9b48328b2a01b4041cfc621