### PR TITLE
Add undo/redo support

### DIFF
--- a/src/core/history.py
+++ b/src/core/history.py
@@ -69,7 +69,9 @@ class FileWriteCommand(Command):
             try:
                 with open(path, "r", encoding=encoding) as f:
                     self._prev_content = f.read()
-            except Exception:
+            except Exception as e:
+                import logging
+                logging.error(f"Failed to read file {path}: {e}", exc_info=True)
                 self._prev_content = ""
 
     def execute(self) -> Any:

--- a/src/core/history.py
+++ b/src/core/history.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import os
+from typing import Any, List, Optional
+
+
+class Command:
+    """Abstract command with execute and undo."""
+
+    def execute(self) -> Any:
+        raise NotImplementedError
+
+    def undo(self) -> Any:
+        raise NotImplementedError
+
+
+class UndoRedoManager:
+    """Simple undo/redo stack manager."""
+
+    def __init__(self) -> None:
+        self._undo_stack: List[Command] = []
+        self._redo_stack: List[Command] = []
+
+    def execute(self, command: Command) -> Any:
+        result = command.execute()
+        self._undo_stack.append(command)
+        self._redo_stack.clear()
+        return result
+
+    def undo_last(self) -> bool:
+        if not self._undo_stack:
+            return False
+        cmd = self._undo_stack.pop()
+        cmd.undo()
+        self._redo_stack.append(cmd)
+        return True
+
+    def redo_last(self) -> bool:
+        if not self._redo_stack:
+            return False
+        cmd = self._redo_stack.pop()
+        cmd.execute()
+        self._undo_stack.append(cmd)
+        return True
+
+
+class FileWriteCommand(Command):
+    """Command for writing a file with undo support."""
+
+    def __init__(
+        self,
+        file_tools: "FileTools",
+        path: str,
+        content: str,
+        *,
+        encoding: str = "utf-8",
+        overwrite: bool = True,
+    ) -> None:
+        from src.tools.file_tools import FileTools
+
+        self.file_tools = file_tools
+        self.path = path
+        self.content = content
+        self.encoding = encoding
+        self.overwrite = overwrite
+        self._prev_exists = os.path.exists(path)
+        self._prev_content: Optional[str] = None
+        if self._prev_exists:
+            try:
+                with open(path, "r", encoding=encoding) as f:
+                    self._prev_content = f.read()
+            except Exception:
+                self._prev_content = ""
+
+    def execute(self) -> Any:
+        return self.file_tools.write_file(
+            self.path, self.content, self.encoding, self.overwrite
+        )
+
+    def undo(self) -> Any:
+        if self._prev_exists:
+            self.file_tools.write_file(
+                self.path, self._prev_content or "", self.encoding, overwrite=True
+            )
+        else:
+            if os.path.exists(self.path):
+                self.file_tools.delete_file(self.path)
+
+
+class MemoryRememberCommand(Command):
+    """Command for remembering a value with undo support."""
+
+    def __init__(self, memory_manager: "MemoryManager", key: str, value: str, category: str) -> None:
+        from src.core.memory import MemoryManager
+
+        self.memory_manager = memory_manager
+        self.key = key
+        self.value = value
+        self.category = category
+        self._prev = memory_manager.recall(key)
+
+    def execute(self) -> Any:
+        return self.memory_manager.remember(self.key, self.value, self.category)
+
+    def undo(self) -> Any:
+        if self._prev:
+            self.memory_manager.remember(
+                self.key,
+                self._prev["value"],
+                self._prev.get("category", "general"),
+            )
+        else:
+            self.memory_manager.forget(self.key)
+
+
+class MemoryForgetCommand(Command):
+    """Command for forgetting a value with undo support."""
+
+    def __init__(self, memory_manager: "MemoryManager", key: str) -> None:
+        from src.core.memory import MemoryManager
+
+        self.memory_manager = memory_manager
+        self.key = key
+        self._prev = memory_manager.recall(key)
+
+    def execute(self) -> Any:
+        return self.memory_manager.forget(self.key)
+
+    def undo(self) -> Any:
+        if self._prev:
+            self.memory_manager.remember(
+                self.key,
+                self._prev["value"],
+                self._prev.get("category", "general"),
+            )
+

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -40,6 +40,8 @@ class JanAssistantGUI:
         self.root = tk.Tk()
         self.root.title("🤖 Jan Assistant Pro")
         self.root.geometry(self.config.window_size)
+        self.root.bind("<Control-z>", lambda e: self.undo_action())
+        self.root.bind("<Control-y>", lambda e: self.redo_action())
 
         # Apply theme
         if self.config.theme == "dark":
@@ -155,6 +157,8 @@ class JanAssistantGUI:
             ("⚙️ Settings", self.show_settings, "#607D8B"),
             ("🔧 Test API", self.test_api, "#2196F3"),
             ("🗑️ Clear", self.clear_chat, "#F44336"),
+            ("↩️ Undo", self.undo_action, "#795548"),
+            ("↪️ Redo", self.redo_action, "#009688"),
         ]
 
         for text, command, color in buttons:
@@ -407,6 +411,20 @@ class JanAssistantGUI:
             self.chat_display.config(state=tk.DISABLED)
             self.controller.conversation_history = []
             self.add_to_chat("🤖 Assistant", "Chat cleared! How can I help?")
+
+    def undo_action(self):
+        """Undo last operation and show result."""
+        if self.controller.undo_last():
+            self.add_to_chat("System", "Undone")
+        else:
+            self.add_to_chat("System", "Nothing to undo")
+
+    def redo_action(self):
+        """Redo last undone operation and show result."""
+        if self.controller.redo_last():
+            self.add_to_chat("System", "Redone")
+        else:
+            self.add_to_chat("System", "Nothing to redo")
 
     def run(self):
         """Start the GUI main loop"""

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -1,0 +1,33 @@
+import os
+from src.core.app_controller import AppController
+from tests.factories import ConfigFactory
+
+
+def test_undo_redo_file_write(tmp_path):
+    cfg = ConfigFactory(tmp_dir=tmp_path)
+    controller = AppController(cfg)
+    file_path = tmp_path / "undo.txt"
+
+    controller._handle_tool_call(f"TOOL_WRITE_FILE:{file_path}|hello")
+    assert file_path.read_text() == "hello"
+
+    controller.undo_last()
+    assert not file_path.exists()
+
+    controller.redo_last()
+    assert file_path.read_text() == "hello"
+
+
+def test_undo_redo_memory(tmp_path):
+    cfg = ConfigFactory(tmp_dir=tmp_path)
+    controller = AppController(cfg)
+
+    controller._handle_tool_call("TOOL_REMEMBER:foo|bar|general")
+    assert controller.memory_manager.recall("foo")
+
+    controller.undo_last()
+    assert controller.memory_manager.recall("foo") is None
+
+    controller.redo_last()
+    mem = controller.memory_manager.recall("foo")
+    assert mem and mem["value"] == "bar"


### PR DESCRIPTION
## Summary
- add `UndoRedoManager` with command objects for file and memory ops
- integrate history stack with `AppController`
- add Undo/Redo buttons and shortcuts in GUI
- implement tests for undo/redo functionality

## Testing
- `pytest tests/test_history.py -q`
- `pytest -q` *(fails: benchmark fixture missing)*

------
https://chatgpt.com/codex/tasks/task_e_68571641417483289133a7b980cc7efe