### PR TITLE
Add keyboard shortcuts with docs and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A **professional-grade**, local-first AI assistant with enterprise-ready archite
 - 🔵 **Connection Indicator**: Real-time API status with latency
 - ⬆️⬇️ **History Navigation**: Cycle through previous prompts
 - ✨ **Autocomplete**: Suggestions while typing commands
+- ⌨️ **Keyboard Shortcuts**: Ctrl+S save, Ctrl+M memory, Ctrl+Z/Y undo/redo, F1 help
 - 🧩 **Plugin Loader**: Load third-party tools dynamically
 
 ### Enterprise Features ✨ **NEW**
@@ -44,7 +45,9 @@ A **professional-grade**, local-first AI assistant with enterprise-ready archite
 
 The main view shows a progress bar at the top-right and a colored connection indicator
 next to the send button. Use the up/down arrow keys to navigate your message history,
-and enjoy inline autocomplete suggestions while typing.
+and enjoy inline autocomplete suggestions while typing. Common shortcuts include
+`Ctrl+S` to save the chat, `Ctrl+M` for the memory manager, `Ctrl+Z`/`Ctrl+Y` to
+undo or redo, and `F1` for contextual help.
 
 ## 📋 Requirements
 

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -26,6 +26,7 @@
 - **Comprehensive Testing**: Full test coverage
 - **Progress Bar** and **Connection Indicator** for clear status
 - **History Navigation** with **Autocomplete** in the GUI
+- **Keyboard Shortcuts**: Ctrl+S save, Ctrl+M memory, Ctrl+Z/Y undo/redo, F1 help
 
 ## Architecture
 

--- a/src/gui/enhanced_widgets.py
+++ b/src/gui/enhanced_widgets.py
@@ -54,6 +54,11 @@ class ChatInput(tk.Entry):
         self.bind("<Return>", self._on_submit)
         self.bind("<Up>", self._on_up)
         self.bind("<Down>", self._on_down)
+        self.bind("<Control-s>", self._on_save)
+        self.bind("<Control-m>", self._on_memory)
+        self.bind("<Control-z>", self._on_undo)
+        self.bind("<Control-y>", self._on_redo)
+        self.bind("<F1>", self._on_help)
 
     def _on_submit(self, event=None):
         text = self.get().strip()
@@ -97,6 +102,30 @@ class ChatInput(tk.Entry):
     def submit(self):
         """Public method to trigger the send callback."""
         self._on_submit()
+
+    # ------------------------------------------------------------------
+    # Shortcut event handlers
+    # ------------------------------------------------------------------
+
+    def _trigger(self, event_name: str):
+        """Generate a virtual event for the bound action."""
+        self.event_generate(event_name)
+        return "break"
+
+    def _on_save(self, event=None):
+        return self._trigger("<<SaveChat>>")
+
+    def _on_memory(self, event=None):
+        return self._trigger("<<ViewMemory>>")
+
+    def _on_undo(self, event=None):
+        return self._trigger("<<UndoAction>>")
+
+    def _on_redo(self, event=None):
+        return self._trigger("<<RedoAction>>")
+
+    def _on_help(self, event=None):
+        return self._trigger("<<ShowHelp>>")
 
 
 class EnhancedChatDisplay(tk.Text):

--- a/src/gui/enhanced_widgets.py
+++ b/src/gui/enhanced_widgets.py
@@ -51,14 +51,15 @@ class ChatInput(tk.Entry):
         self.history = []
         self.history_index = None
 
-        self.bind("<Return>", self._on_submit)
-        self.bind("<Up>", self._on_up)
-        self.bind("<Down>", self._on_down)
-        self.bind("<Control-s>", self._on_save)
-        self.bind("<Control-m>", self._on_memory)
-        self.bind("<Control-z>", self._on_undo)
-        self.bind("<Control-y>", self._on_redo)
-        self.bind("<F1>", self._on_help)
+        self.shortcut_manager = ShortcutManager(self)
+        self.shortcut_manager.register("<Return>", self._on_submit)
+        self.shortcut_manager.register("<Up>", self._on_up)
+        self.shortcut_manager.register("<Down>", self._on_down)
+        self.shortcut_manager.register("<Control-s>", self._on_save)
+        self.shortcut_manager.register("<Control-m>", self._on_memory)
+        self.shortcut_manager.register("<Control-z>", self._on_undo)
+        self.shortcut_manager.register("<Control-y>", self._on_redo)
+        self.shortcut_manager.register("<F1>", self._on_help)
 
     def _on_submit(self, event=None):
         text = self.get().strip()

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -41,13 +41,18 @@ class JanAssistantGUI:
         self.root.title("🤖 Jan Assistant Pro")
         self.root.geometry(self.config.window_size)
         # Keyboard shortcuts
-        self.root.bind("<Control-s>", lambda e: self.save_chat())
-        self.root.bind("<Control-m>", lambda e: self.view_memory())
-        self.root.bind("<Control-z>", lambda e: self.undo_action())
-        self.root.bind("<Control-y>", lambda e: self.redo_action())
-        self.root.bind("<F1>", lambda e: self.show_help())
+        # Map direct keyboard shortcuts to virtual events
+        shortcut_to_event = {
+            "<Control-s>": "<<SaveChat>>",
+            "<Control-m>": "<<ViewMemory>>",
+            "<Control-z>": "<<UndoAction>>",
+            "<Control-y>": "<<RedoAction>>",
+            "<F1>": "<<ShowHelp>>",
+        }
+        for shortcut, event in shortcut_to_event.items():
+            self.root.bind(shortcut, lambda e, event=event: self.root.event_generate(event))
 
-        # Virtual events from ChatInput
+        # Bind virtual events to action methods
         self.root.bind("<<SaveChat>>", lambda e: self.save_chat())
         self.root.bind("<<ViewMemory>>", lambda e: self.view_memory())
         self.root.bind("<<UndoAction>>", lambda e: self.undo_action())

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -40,8 +40,19 @@ class JanAssistantGUI:
         self.root = tk.Tk()
         self.root.title("🤖 Jan Assistant Pro")
         self.root.geometry(self.config.window_size)
+        # Keyboard shortcuts
+        self.root.bind("<Control-s>", lambda e: self.save_chat())
+        self.root.bind("<Control-m>", lambda e: self.view_memory())
         self.root.bind("<Control-z>", lambda e: self.undo_action())
         self.root.bind("<Control-y>", lambda e: self.redo_action())
+        self.root.bind("<F1>", lambda e: self.show_help())
+
+        # Virtual events from ChatInput
+        self.root.bind("<<SaveChat>>", lambda e: self.save_chat())
+        self.root.bind("<<ViewMemory>>", lambda e: self.view_memory())
+        self.root.bind("<<UndoAction>>", lambda e: self.undo_action())
+        self.root.bind("<<RedoAction>>", lambda e: self.redo_action())
+        self.root.bind("<<ShowHelp>>", lambda e: self.show_help())
 
         # Apply theme
         if self.config.theme == "dark":
@@ -368,6 +379,17 @@ class JanAssistantGUI:
             bg=self.bg_color,
             fg=self.fg_color,
         ).pack(anchor=tk.W)
+
+    def show_help(self):
+        """Display contextual help."""
+        message = (
+            "Keyboard shortcuts:\n"
+            "Ctrl+S - Save chat\n"
+            "Ctrl+M - Memory manager\n"
+            "Ctrl+Z/Y - Undo/Redo\n"
+            "F1 - Help"
+        )
+        messagebox.showinfo("Help", message)
 
     def test_api(self):
         """Test API connection"""

--- a/tests/test_gui_widgets.py
+++ b/tests/test_gui_widgets.py
@@ -40,6 +40,26 @@ class TestChatInput(unittest.TestCase):
         self.assertEqual(input_widget.get(), "second")
         root.destroy()
 
+    def test_shortcut_events(self):
+        root = create_root_or_skip()
+        events = []
+        root.bind("<<SaveChat>>", lambda e: events.append("save"))
+        root.bind("<<ViewMemory>>", lambda e: events.append("memory"))
+        root.bind("<<UndoAction>>", lambda e: events.append("undo"))
+        root.bind("<<RedoAction>>", lambda e: events.append("redo"))
+        root.bind("<<ShowHelp>>", lambda e: events.append("help"))
+
+        input_widget = ChatInput(root)
+
+        input_widget._on_save()
+        input_widget._on_memory()
+        input_widget._on_undo()
+        input_widget._on_redo()
+        input_widget._on_help()
+
+        self.assertEqual(events, ["save", "memory", "undo", "redo", "help"])
+        root.destroy()
+
 
 class TestStatusBar(unittest.TestCase):
     def test_connection_indicator(self):


### PR DESCRIPTION
## Summary
- bind additional shortcuts in the GUI and ChatInput
- document shortcuts in README and developer guide
- add tests for shortcut events

## Testing
- `pytest tests/test_gui_widgets.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68571a44c2608328bc45e1ed4fe1f674