### PR TITLE
Add progress callbacks to tools and GUI

### DIFF
--- a/src/gui/enhanced_widgets.py
+++ b/src/gui/enhanced_widgets.py
@@ -1,7 +1,7 @@
 """GUI widget enhancements for Jan Assistant Pro."""
 
-from datetime import datetime
 import tkinter as tk
+from datetime import datetime
 from tkinter import ttk
 
 
@@ -10,10 +10,12 @@ class StatusBar(tk.Frame):
 
     def __init__(self, master, **kwargs):
         super().__init__(master, **kwargs)
-        bg = kwargs.get("bg", master["bg"] if isinstance(master, tk.Widget) else "white")
+        bg = kwargs.get(
+            "bg", master["bg"] if isinstance(master, tk.Widget) else "white"
+        )
         self.configure(bg=bg)
 
-        self.indicator = tk.Label(self, text="\u25CF", fg="#ff0000", bg=bg)
+        self.indicator = tk.Label(self, text="\u25cf", fg="#ff0000", bg=bg)
         self.indicator.pack(side=tk.LEFT, padx=(0, 5))
 
         self.label = tk.Label(self, text="Ready", anchor="w", fg="#00ff00", bg=bg)
@@ -22,17 +24,43 @@ class StatusBar(tk.Frame):
         self.progress = ttk.Progressbar(self, mode="indeterminate", length=80)
         self.progress_running = False
 
-    def set_status(self, text: str, color: str = "#00ff00", progress: bool = False) -> None:
-        """Update the status text and optionally show progress."""
+    def set_status(
+        self,
+        text: str,
+        color: str = "#00ff00",
+        progress: bool | tuple[int, int] = False,
+    ) -> None:
+        """Update the status text and optionally show progress.
+
+        The ``progress`` argument accepts either ``True``/``False`` to toggle an
+        indeterminate progress bar, or a ``(value, maximum)`` tuple to show
+        determinate progress.
+        """
+
         self.label.config(text=text, fg=color)
-        if progress and not self.progress_running:
-            self.progress.pack(side=tk.RIGHT, padx=5)
-            self.progress.start()
-            self.progress_running = True
-        elif not progress and self.progress_running:
-            self.progress.stop()
-            self.progress.pack_forget()
-            self.progress_running = False
+
+        if progress is True:
+            if not self.progress_running or self.progress["mode"] != "indeterminate":
+                self.progress.config(mode="indeterminate")
+                self.progress.pack(side=tk.RIGHT, padx=5)
+                self.progress.start()
+                self.progress_running = True
+        elif isinstance(progress, tuple):
+            value, maximum = progress
+            if not self.progress_running or self.progress["mode"] != "determinate":
+                self.progress.config(mode="determinate", maximum=maximum)
+                self.progress.pack(side=tk.RIGHT, padx=5)
+                self.progress_running = True
+            self.progress["value"] = value
+            if value >= maximum:
+                self.progress.pack_forget()
+                self.progress_running = False
+        else:
+            if self.progress_running:
+                self.progress.stop()
+                self.progress.pack_forget()
+                self.progress_running = False
+
         self.update_idletasks()
 
     def set_connected(self, connected: bool) -> None:

--- a/src/gui/enhanced_widgets.py
+++ b/src/gui/enhanced_widgets.py
@@ -15,7 +15,8 @@ class StatusBar(tk.Frame):
         )
         self.configure(bg=bg)
 
-        self.indicator = tk.Label(self, text="\u25cf", fg="#ff0000", bg=bg)
+        # Using U+25CF (BLACK CIRCLE) to represent the connection indicator.
+        self.indicator = tk.Label(self, text="\u25CF", fg="#ff0000", bg=bg)
         self.indicator.pack(side=tk.LEFT, padx=(0, 5))
 
         self.label = tk.Label(self, text="Ready", anchor="w", fg="#00ff00", bg=bg)

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -287,9 +287,20 @@ class JanAssistantGUI:
     def process_message(self, message: str) -> Dict[str, Any]:
         """Process message with the controller"""
         try:
-            return self.controller.process_message(message)
+            return self.controller.process_message(
+                message, progress_callback=self._progress_callback
+            )
         except Exception as e:
             return {"type": "error", "content": str(e)}
+
+    def _progress_callback(self, current: int, total: int) -> None:
+        """Update progress from worker threads."""
+        self.root.after(
+            0,
+            lambda: self.status_bar.set_status(
+                "Working...", "#00ff00", progress=(current, total)
+            ),
+        )
 
     # GUI Event handlers
     def save_chat(self):

--- a/src/tools/file_tools.py
+++ b/src/tools/file_tools.py
@@ -473,12 +473,11 @@ class FileTools:
             files = []
             directories = []
 
-            items = list(path.glob(pattern))
+            all_items = list(path.glob(pattern))
+            items = [i for i in all_items if include_hidden or not i.name.startswith(".")]
             total = len(items)
 
             for idx, item in enumerate(items, start=1):
-                if not include_hidden and item.name.startswith("."):
-                    continue
 
                 item_info = {
                     "name": item.name,

--- a/tests/test_file_tools.py
+++ b/tests/test_file_tools.py
@@ -125,3 +125,33 @@ def test_list_files_disk_cache(tmp_path):
     (tmp_path / "c.txt").write_text("3")
     result_clear = tools.list_files(str(tmp_path), clear_cache=True)
     assert result_clear["total_files"] == 3
+
+
+def test_copy_file_progress_callback(tmp_path):
+    tools = FileTools()
+    src = tmp_path / "src.txt"
+    dst = tmp_path / "dst.txt"
+    src.write_bytes(b"x" * 2048)
+    calls = []
+
+    def progress(current, total):
+        calls.append((current, total))
+
+    tools.copy_file(str(src), str(dst), progress_callback=progress)
+    assert dst.exists()
+    assert calls
+    assert calls[-1][0] == calls[-1][1]
+
+
+def test_list_files_progress_callback(tmp_path):
+    tools = FileTools()
+    for i in range(3):
+        (tmp_path / f"f{i}.txt").write_text("x")
+    calls = []
+
+    def progress(current, total):
+        calls.append((current, total))
+
+    tools.list_files(str(tmp_path), progress_callback=progress, use_cache=False)
+    assert calls
+    assert calls[-1][0] == calls[-1][1]

--- a/tests/test_gui_widgets.py
+++ b/tests/test_gui_widgets.py
@@ -71,6 +71,16 @@ class TestStatusBar(unittest.TestCase):
         self.assertEqual(bar.indicator.cget("fg"), "#ff0000")
         root.destroy()
 
+    def test_determinate_progress(self):
+        root = create_root_or_skip()
+        bar = StatusBar(root)
+        bar.set_status("Working", progress=(1, 2))
+        self.assertEqual(bar.progress["mode"], "determinate")
+        self.assertEqual(bar.progress["value"], 1)
+        bar.set_status("Done", progress=(2, 2))
+        self.assertFalse(bar.progress.winfo_ismapped())
+        root.destroy()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_system_tools.py
+++ b/tests/test_system_tools.py
@@ -101,6 +101,20 @@ def test_list_directory(tmp_path):
     assert "d1" in names_dirs
 
 
+def test_list_directory_progress_callback(tmp_path):
+    tools = SystemTools()
+    (tmp_path / "d1").mkdir()
+    (tmp_path / "f1.txt").write_text("x")
+    calls = []
+
+    def progress(current, total):
+        calls.append((current, total))
+
+    tools.list_directory(str(tmp_path), progress_callback=progress)
+    assert calls
+    assert calls[-1][0] == calls[-1][1]
+
+
 def test_list_directory_invalid(tmp_path):
     tools = SystemTools()
     res = tools.list_directory(str(tmp_path / "nope"))


### PR DESCRIPTION
## Summary
- support determinate progress in `StatusBar.set_status`
- report progress from `FileTools.list_files` and `copy_file`
- add progress reporting to `SystemTools.list_directory`
- plumb progress callbacks through `AppController` and GUI
- test new progress callbacks

## Testing
- `pytest tests/test_file_tools.py -k progress_callback -q`
- `pytest tests/test_system_tools.py::test_list_directory_progress_callback -q`
- `pytest tests/test_gui_widgets.py::TestStatusBar::test_determinate_progress -q`

------
https://chatgpt.com/codex/tasks/task_e_6857202499e48328bb771ac58a78b254