### PR TITLE
Add drag-and-drop file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A **professional-grade**, local-first AI assistant with enterprise-ready archite
 - 🔵 **Connection Indicator**: Real-time API status with latency
 - ⬆️⬇️ **History Navigation**: Cycle through previous prompts
 - ✨ **Autocomplete**: Suggestions while typing commands
+- 🖱️ **Drag & Drop**: Drop files to pre-fill commands
 - ⌨️ **Keyboard Shortcuts**: Ctrl+S save, Ctrl+M memory, Ctrl+Z/Y undo/redo, F1 help
 - 🧩 **Plugin Loader**: Load third-party tools dynamically
 

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -26,6 +26,7 @@
 - **Comprehensive Testing**: Full test coverage
 - **Progress Bar** and **Connection Indicator** for clear status
 - **History Navigation** with **Autocomplete** in the GUI
+- **Drag & Drop** support for quickly loading files
 - **Keyboard Shortcuts**: Ctrl+S save, Ctrl+M memory, Ctrl+Z/Y undo/redo, F1 help
 
 ## Architecture

--- a/tests/test_gui_widgets.py
+++ b/tests/test_gui_widgets.py
@@ -7,7 +7,11 @@ import pytest
 sys.path.insert(
     0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src"))
 )
-from src.gui.enhanced_widgets import ChatInput, StatusBar  # noqa: E402
+from src.gui.enhanced_widgets import (
+    ChatInput,
+    EnhancedChatDisplay,
+    StatusBar,
+)
 
 tk = pytest.importorskip("tkinter", reason="required for GUI widget tests")
 
@@ -58,6 +62,37 @@ class TestChatInput(unittest.TestCase):
         input_widget._on_help()
 
         self.assertEqual(events, ["save", "memory", "undo", "redo", "help"])
+        root.destroy()
+
+    def test_drop_populates_command(self):
+        root = create_root_or_skip()
+        input_widget = ChatInput(root)
+
+        class Event:
+            def __init__(self, data):
+                self.data = data
+
+        input_widget._on_drop(Event("/tmp/test.txt"))
+        self.assertEqual(input_widget.get(), "TOOL_READ_FILE: /tmp/test.txt")
+        root.destroy()
+
+
+class TestEnhancedChatDisplay(unittest.TestCase):
+    def test_drop_calls_callback(self):
+        root = create_root_or_skip()
+        called = []
+
+        def cb(paths):
+            called.append(paths)
+
+        display = EnhancedChatDisplay(root, drop_callback=cb)
+
+        class Event:
+            def __init__(self, data):
+                self.data = data
+
+        display._on_drop(Event("/tmp/foo.txt"))
+        self.assertEqual(called, [["/tmp/foo.txt"]])
         root.destroy()
 
 


### PR DESCRIPTION
## Summary
- integrate optional TkinterDnD drag-and-drop in `EnhancedChatDisplay` and `ChatInput`
- handle dropped files in the main GUI by inserting a `TOOL_READ_FILE` command
- document drag-and-drop feature in README and developer guide
- add GUI tests covering drop events

## Testing
- `ruff check src/ tests/` *(fails: Import block is un-sorted or un-formatted)*
- `mypy src/gui/enhanced_widgets.py src/gui/main_window.py` *(fails: found 192 errors in 30 files)*
- `pytest tests/test_gui_widgets.py::TestChatInput.test_drop_populates_command tests/test_gui_widgets.py::TestEnhancedChatDisplay.test_drop_calls_callback -q` *(fails: ModuleNotFoundError: No module named 'aiohttp')*

------
https://chatgpt.com/codex/tasks/task_e_685727dfb5d88328aa58dce60976bb4b